### PR TITLE
Benchmarking - Add tensor_parallel_size arg for multi-gpu benchmarking

### DIFF
--- a/neuralmagic/benchmarks/common.py
+++ b/neuralmagic/benchmarks/common.py
@@ -44,8 +44,9 @@ def script_args_to_cla(config: NamedTuple) -> Iterable[list[str]]:
     key_args_cla = list(map(lambda k: f"--{k}", key_args))
 
     # Remove empty lists from arg_lists and remove key args from keys
-    arg_lists = filter(lambda arg_list: len(arg_list) != 0, arg_lists)
-    keys = filter(lambda k: k not in key_args, keys)
+    arg_lists = list(filter(lambda arg_list: len(arg_list) != 0, arg_lists))
+    keys = list(filter(lambda k: k not in key_args, keys))
+    assert len(keys) == len(arg_lists)
 
     for args in itertools.product(*arg_lists):
         cla = key_args_cla

--- a/neuralmagic/benchmarks/configs/benchmark_serving.json
+++ b/neuralmagic/benchmarks/configs/benchmark_serving.json
@@ -8,7 +8,7 @@
 				"mistralai/Mistral-7B-Instruct-v0.2",
 				"NousResearch/Llama-2-7b-chat-hf"
 			],
-			"tensor_parallel_size" : 1,
+			"use_all_available_gpus" : "",
 			"max_model_lens": [
 				4096
 			],

--- a/neuralmagic/benchmarks/configs/benchmark_serving.json
+++ b/neuralmagic/benchmarks/configs/benchmark_serving.json
@@ -8,9 +8,7 @@
 				"mistralai/Mistral-7B-Instruct-v0.2",
 				"NousResearch/Llama-2-7b-chat-hf"
 			],
-			"tensor_parallel_size" : [
-				1
-			],
+			"tensor_parallel_size" : 1,
 			"max_model_lens": [
 				4096
 			],

--- a/neuralmagic/benchmarks/configs/benchmark_serving.json
+++ b/neuralmagic/benchmarks/configs/benchmark_serving.json
@@ -8,6 +8,9 @@
 				"mistralai/Mistral-7B-Instruct-v0.2",
 				"NousResearch/Llama-2-7b-chat-hf"
 			],
+			"tensor_parallel_size" : [
+				1
+			],
 			"max_model_lens": [
 				4096
 			],
@@ -19,36 +22,6 @@
 					"100,1",
 					"200,2",
 					"500,5"
-				],
-				"best-of": [
-					1
-				],
-				"dataset": [
-					"sharegpt"
-				]
-			}
-		},
-		{
-			"description": "Benchmark vllm serving",
-			"models": [
-				"facebook/opt-125m",
-				"TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-				"mistralai/Mistral-7B-Instruct-v0.2",
-				"NousResearch/Llama-2-7b-chat-hf"
-			],
-			"max_model_lens": [
-				4096
-			],
-			"sparsity": [],
-			"script_name": "benchmark_serving",
-			"script_args": {
-				"num-prompts_": [
-					50,
-					100
-				],
-				"request-rate_": [
-					0.5,
-					"inf"
 				],
 				"best-of": [
 					1

--- a/neuralmagic/benchmarks/configs/benchmark_throughput.json
+++ b/neuralmagic/benchmarks/configs/benchmark_throughput.json
@@ -20,9 +20,6 @@
 				"output-len": [
 					128
 				],
-				"tensor-parallel-size_": [
-					1
-				],
 				"n": [
 					1
 				],
@@ -34,7 +31,8 @@
 				],
 				"dtype": [
 					"auto"
-				]
+				],
+				"use-all-available-gpus_" : []
 			}
 		},
 		{
@@ -64,9 +62,6 @@
 				"output-len": [
 					1
 				],
-				"tensor-parallel-size_": [
-					1
-				],
 				"n": [
 					1
 				],
@@ -78,7 +73,8 @@
 				],
 				"dtype": [
 					"auto"
-				]
+				],
+				"use-all-available-gpus_" : []
 			}
 		},
 		{
@@ -101,9 +97,6 @@
 				"output-len": [
 					128
 				],
-				"tensor-parallel-size_": [
-					1
-				],
 				"n": [
 					1
 				],
@@ -120,7 +113,8 @@
 				],
 				"dtype": [
 					"auto"
-				]
+				],
+				"use-all-available-gpus_" : []
 			}
 		}
 	]

--- a/neuralmagic/benchmarks/configs/benchmark_throughput.json
+++ b/neuralmagic/benchmarks/configs/benchmark_throughput.json
@@ -20,7 +20,7 @@
 				"output-len": [
 					128
 				],
-				"tensor-parallel-size": [
+				"tensor-parallel-size_": [
 					1
 				],
 				"n": [
@@ -64,7 +64,7 @@
 				"output-len": [
 					1
 				],
-				"tensor-parallel-size": [
+				"tensor-parallel-size_": [
 					1
 				],
 				"n": [
@@ -101,7 +101,7 @@
 				"output-len": [
 					128
 				],
-				"tensor-parallel-size": [
+				"tensor-parallel-size_": [
 					1
 				],
 				"n": [

--- a/neuralmagic/benchmarks/datasets_registry.py
+++ b/neuralmagic/benchmarks/datasets_registry.py
@@ -38,6 +38,8 @@ def make_dataset_triples(prompts: List[str], completions: List[str],
 
         # Make into dataset tripe.
         dataset.append((prompt, prompt_len, output_len))
+        if (len(dataset) >= dataset_args.num_samples * 2):
+            break
 
     # Sample num_requests from the list.
     print(len(dataset))

--- a/neuralmagic/benchmarks/run_benchmark_serving.py
+++ b/neuralmagic/benchmarks/run_benchmark_serving.py
@@ -9,10 +9,30 @@ from pathlib import Path
 
 from neuralmagic.tools.call_cmd import call_cmd
 from neuralmagic.benchmarks.common import download_model, max_model_length_from_model_id, script_args_to_cla, benchmark_configs
-from neuralmagic.benchmarks.scripts.common import warmup_server
+from neuralmagic.benchmarks.scripts.common import warmup_server, num_available_gpus
 
 BENCH_SERVER_HOST = "localhost"
 BENCH_SERVER_PORT = 9000
+
+
+def get_tensor_parallel_size(config: NamedTuple) -> int:
+
+    num_tp_directives = [
+        hasattr(config, 'tensor_parallel_size'),
+        hasattr(config, 'use_all_available_gpus')
+    ].count(True)
+    if num_tp_directives == 0:
+        # by default - use just one GPU
+        return 1
+
+    # must have exactly one directive
+    assert num_tp_directives == 1
+
+    tensor_parallel_size = config.tensor_parallel_size if hasattr(
+        config, 'tensor_parallel_size') else num_available_gpus()
+    assert tensor_parallel_size > 0 and tensor_parallel_size <= num_available_gpus(
+    )
+    return tensor_parallel_size
 
 
 def is_server_running(host: str, port: int, timeout=300) -> bool:
@@ -62,6 +82,8 @@ def run_benchmark_serving_script(config: NamedTuple,
             assert server_process is not None
             server_process.kill()
 
+    tensor_parallel_size = get_tensor_parallel_size(config)
+
     script_path = f"neuralmagic.benchmarks.scripts.{config.script_name}"
 
     sparsities = [None] if len(config.sparsity) == 0 else config.sparsity
@@ -84,10 +106,20 @@ def run_benchmark_serving_script(config: NamedTuple,
 
         for max_model_len in max_model_lens:
 
-            server_cmd = f"python3 -m vllm.entrypoints.api_server --model {model} --tokenizer {model} --max-model-len {max_model_len} --host {BENCH_SERVER_HOST} --port {BENCH_SERVER_PORT} --disable-log-requests"
-
+            server_args = {
+                "model": model,
+                "tokenizer": model,
+                "max-model-len": max_model_len,
+                "host": BENCH_SERVER_HOST,
+                "port": BENCH_SERVER_PORT,
+                "tensor-parallel-size": tensor_parallel_size,
+                "disable-log-requests": ""
+            }
             if sparsity:
-                server_cmd += f" --sparsity {sparsity} "
+                server_args["sparsity"] = sparsity
+
+            server_cmd = "python3 -m vllm.entrypoints.api_server " + \
+                            " ".join([f"--{k} {v}" for k, v in server_args.items()])
 
             for script_args in script_args_to_cla(config):
                 bench_cmd = (["python3", "-m"
@@ -98,9 +130,8 @@ def run_benchmark_serving_script(config: NamedTuple,
                              ["--host", f"{BENCH_SERVER_HOST}"])
 
                 if output_directory:
-                    bench_cmd = bench_cmd + [
-                        "--save-directory", f"{output_directory}"
-                    ]
+                    bench_cmd += (["--save-directory", f"{output_directory}"] +
+                                  ["--server-args", f"{server_args}"])
 
                 run_bench(server_cmd, bench_cmd, model)
 

--- a/neuralmagic/benchmarks/run_benchmark_serving.py
+++ b/neuralmagic/benchmarks/run_benchmark_serving.py
@@ -131,8 +131,10 @@ def run_benchmark_serving_script(config: NamedTuple,
 
                 if output_directory:
                     bench_cmd += (["--save-directory", f"{output_directory}"] +
-                                  ["--server-args", f"{server_args}"] +
-                                  ["--server-tensor-parallel-size", f"{tensor_parallel_size}"])
+                                  ["--server-args", f"{server_args}"] + [
+                                      "--server-tensor-parallel-size",
+                                      f"{tensor_parallel_size}"
+                                  ])
 
                 run_bench(server_cmd, bench_cmd, model)
 

--- a/neuralmagic/benchmarks/run_benchmark_serving.py
+++ b/neuralmagic/benchmarks/run_benchmark_serving.py
@@ -131,7 +131,8 @@ def run_benchmark_serving_script(config: NamedTuple,
 
                 if output_directory:
                     bench_cmd += (["--save-directory", f"{output_directory}"] +
-                                  ["--server-args", f"{server_args}"])
+                                  ["--server-args", f"{server_args}"] +
+                                  ["--server-tensor-parallel-size", f"{tensor_parallel_size}"])
 
                 run_bench(server_cmd, bench_cmd, model)
 

--- a/neuralmagic/benchmarks/run_benchmark_serving.py
+++ b/neuralmagic/benchmarks/run_benchmark_serving.py
@@ -30,8 +30,8 @@ def get_tensor_parallel_size(config: NamedTuple) -> int:
 
     tensor_parallel_size = config.tensor_parallel_size if hasattr(
         config, 'tensor_parallel_size') else num_available_gpus()
-    assert tensor_parallel_size > 0 and tensor_parallel_size <= num_available_gpus(
-    )
+    assert tensor_parallel_size > 0 and \
+           tensor_parallel_size <= num_available_gpus()
     return tensor_parallel_size
 
 

--- a/neuralmagic/benchmarks/scripts/benchmark_serving.py
+++ b/neuralmagic/benchmarks/scripts/benchmark_serving.py
@@ -273,11 +273,12 @@ def main(args: argparse.Namespace):
     if save_result:
 
         current_dt = datetime.now().strftime("%Y%m%d-%H%M%S")
-        result_json = instantiate_benchmark_results_dict(Path(__file__).name, args.server_tensor_parallel_size)
+        result_json = instantiate_benchmark_results_dict(
+            Path(__file__).name, args.server_tensor_parallel_size)
         result_json["date"] = current_dt
         result_json["script_args"] = vars(args)
 
-        # Populate derived-args for convenience 
+        # Populate derived-args for convenience
         result_json["num_prompts"] = num_prompts
         result_json["request_rate"] =  \
             request_rate if request_rate < float("inf") else "inf"
@@ -414,10 +415,13 @@ if __name__ == "__main__":
                         default=None)
 
     # Server command args
-    parser.add_argument("--server-tensor-parallel-size",
-                        type=int,
-                        default=None,
-                        help="tensor-parallel-size that the benchmarking script was invoked with. It is useful to log this information when storing benchmarking results")
+    parser.add_argument(
+        "--server-tensor-parallel-size",
+        type=int,
+        default=None,
+        help=
+        "tensor-parallel-size that the benchmarking script was invoked with. It is useful to log this information when storing benchmarking results"
+    )
     parser.add_argument(
         "--server-args",
         type=str,
@@ -441,7 +445,7 @@ if __name__ == "__main__":
             assert args.num_prompts_ is not None and args.request_rate_ is not None
         else:
             assert args.num_prompts_ is None and args.request_rate_ is None
-        # Sanity check required logging args 
+        # Sanity check required logging args
         if args.save_directory is not None:
             assert args.server_tensor_parallel_size is not None
 

--- a/neuralmagic/benchmarks/scripts/benchmark_serving.py
+++ b/neuralmagic/benchmarks/scripts/benchmark_serving.py
@@ -274,7 +274,11 @@ def main(args: argparse.Namespace):
 
         current_dt = datetime.now().strftime("%Y%m%d-%H%M%S")
         result_json = instantiate_benchmark_results_dict(
-            Path(__file__).name, args.server_tensor_parallel_size)
+            benchmarking_script_name=Path(__file__).name,
+            tensor_parallel_size=args.server_tensor_parallel_size,
+            model=args.model,
+            tokenizer=args.tokenizer,
+            dataset=args.dataset)
         result_json["date"] = current_dt
         result_json["script_args"] = vars(args)
 

--- a/neuralmagic/benchmarks/scripts/benchmark_serving.py
+++ b/neuralmagic/benchmarks/scripts/benchmark_serving.py
@@ -271,18 +271,14 @@ def main(args: argparse.Namespace):
     # Save config and results to json
     save_result = args.save_directory is not None
     if save_result:
-        result_json = {}
 
         # Setup
         current_dt = datetime.now().strftime("%Y%m%d-%H%M%S")
+
+        result_json = vars(args)
         result_json["date"] = current_dt
         result_json["bench_env"] = get_bench_environment()
-        result_json["backend"] = backend
-        result_json["version"] = args.version
-        result_json["model_id"] = model_id
         result_json["tokenizer_id"] = tokenizer_id
-        result_json["best_of"] = args.best_of
-        result_json["use_beam_search"] = args.use_beam_search
         result_json["num_prompts"] = num_prompts
 
         # Traffic
@@ -388,10 +384,6 @@ if __name__ == "__main__":
         action="store_true",
         help="Specify to disbale tqdm progress bar.",
     )
-    parser.add_argument("--save-directory",
-                        type=str,
-                        default=None,
-                        help="Output directory to store result file")
 
     parser.add_argument(
         "--num-prompts_",
@@ -417,6 +409,18 @@ if __name__ == "__main__":
                             the request arrival times.
                             """,
                         default=None)
+
+    parser.add_argument("--save-directory",
+                        type=str,
+                        default=None,
+                        help="Output directory to store result file")
+    parser.add_argument(
+        "--server-args",
+        type=str,
+        default=None,
+        help=
+        "When we are logging the output, it is useful to log the arguments passed to the server"
+    )
 
     def args_sanity_check(args):
         # Sanity check real-dataset vs synthetic-dataset usecase

--- a/neuralmagic/benchmarks/scripts/benchmark_serving.py
+++ b/neuralmagic/benchmarks/scripts/benchmark_serving.py
@@ -276,6 +276,7 @@ def main(args: argparse.Namespace):
         current_dt = datetime.now().strftime("%Y%m%d-%H%M%S")
 
         result_json = vars(args)
+        result_json["script_name"] = Path(__file__).name
         result_json["date"] = current_dt
         result_json["bench_env"] = get_bench_environment()
         result_json["tokenizer_id"] = tokenizer_id

--- a/neuralmagic/benchmarks/scripts/benchmark_throughput.py
+++ b/neuralmagic/benchmarks/scripts/benchmark_throughput.py
@@ -13,8 +13,16 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Tuple
 from transformers import AutoTokenizer
-from neuralmagic.benchmarks.scripts.common import get_bench_environment, generate_synthetic_requests, warmup_vllm_engine
+from neuralmagic.benchmarks.scripts.common import get_bench_environment, generate_synthetic_requests, warmup_vllm_engine, num_available_gpus
 from neuralmagic.benchmarks.datasets_registry import get_dataset, DatasetArgs
+
+
+def get_tensor_parallel_size(args: argparse.Namespace) -> int:
+    tensor_parallel_size = num_available_gpus(
+    ) if args.use_all_available_gpus_ else args.tensor_parallel_size_
+    assert tensor_parallel_size > 0 and tensor_parallel_size <= num_available_gpus(
+    )
+    return tensor_parallel_size
 
 
 def run_vllm(
@@ -98,7 +106,7 @@ def main(args: argparse.Namespace):
                             args.model,
                             args.tokenizer,
                             args.quantization,
-                            args.tensor_parallel_size,
+                            get_tensor_parallel_size(args),
                             args.seed,
                             args.n,
                             args.use_beam_search,
@@ -130,8 +138,8 @@ def main(args: argparse.Namespace):
         result_json["date"] = current_dt
         result_json["bench_env"] = get_bench_environment()
         result_json.update(vars(args))
-        result_json["request_throughput (per second)"] = request_throughput
-        result_json["token_throughput (per second)"] = token_throughput
+        result_json["request_throughput"] = request_throughput
+        result_json["token_throughput"] = token_throughput
 
         model_id = args.model.replace('/', '_')
         # Save to file
@@ -168,7 +176,6 @@ if __name__ == "__main__":
                         '-q',
                         choices=['awq', 'gptq', 'squeezellm', None],
                         default=None)
-    parser.add_argument("--tensor-parallel-size", "-tp", type=int, default=1)
     parser.add_argument("--n",
                         type=int,
                         default=1,
@@ -204,6 +211,11 @@ if __name__ == "__main__":
                         type=str,
                         default=None,
                         help="Output directory to store result file")
+
+    tp_group = parser.add_mutually_exclusive_group(required=True)
+    tp_group.add_argument("--tensor-parallel-size_", type=int, default=None)
+    tp_group.add_argument("--use-all-available-gpus_", action="store_true")
+
     args = parser.parse_args()
     if args.tokenizer is None:
         args.tokenizer = args.model

--- a/neuralmagic/benchmarks/scripts/benchmark_throughput.py
+++ b/neuralmagic/benchmarks/scripts/benchmark_throughput.py
@@ -134,7 +134,8 @@ def main(args: argparse.Namespace):
 
         # Setup
         current_dt = datetime.now().strftime("%Y%m%d-%H%M%S")
-        result_json = instantiate_benchmark_results_dict(Path(__file__).name, get_tensor_parallel_size(args))
+        result_json = instantiate_benchmark_results_dict(
+            Path(__file__).name, get_tensor_parallel_size(args))
         result_json["date"] = current_dt
         result_json["script_args"] = vars(args)
         result_json["request_throughput"] = request_throughput

--- a/neuralmagic/benchmarks/scripts/benchmark_throughput.py
+++ b/neuralmagic/benchmarks/scripts/benchmark_throughput.py
@@ -135,6 +135,7 @@ def main(args: argparse.Namespace):
 
         # Setup
         current_dt = datetime.now().strftime("%Y%m%d-%H%M%S")
+        result_json["script_name"] = Path(__file__).name
         result_json["date"] = current_dt
         result_json["bench_env"] = get_bench_environment()
         result_json.update(vars(args))

--- a/neuralmagic/benchmarks/scripts/benchmark_throughput.py
+++ b/neuralmagic/benchmarks/scripts/benchmark_throughput.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Tuple
 from transformers import AutoTokenizer
-from neuralmagic.benchmarks.scripts.common import get_bench_environment, generate_synthetic_requests, warmup_vllm_engine, num_available_gpus
+from neuralmagic.benchmarks.scripts.common import instantiate_benchmark_results_dict, generate_synthetic_requests, warmup_vllm_engine, num_available_gpus
 from neuralmagic.benchmarks.datasets_registry import get_dataset, DatasetArgs
 
 
@@ -131,14 +131,12 @@ def main(args: argparse.Namespace):
     # Save config and results to json
     save_result = args.save_directory is not None
     if save_result:
-        result_json = {}
 
         # Setup
         current_dt = datetime.now().strftime("%Y%m%d-%H%M%S")
-        result_json["script_name"] = Path(__file__).name
+        result_json = instantiate_benchmark_results_dict(Path(__file__).name, get_tensor_parallel_size(args))
         result_json["date"] = current_dt
-        result_json["bench_env"] = get_bench_environment()
-        result_json.update(vars(args))
+        result_json["script_args"] = vars(args)
         result_json["request_throughput"] = request_throughput
         result_json["token_throughput"] = token_throughput
 

--- a/neuralmagic/benchmarks/scripts/benchmark_throughput.py
+++ b/neuralmagic/benchmarks/scripts/benchmark_throughput.py
@@ -18,10 +18,10 @@ from neuralmagic.benchmarks.datasets_registry import get_dataset, DatasetArgs
 
 
 def get_tensor_parallel_size(args: argparse.Namespace) -> int:
-    tensor_parallel_size = num_available_gpus(
-    ) if args.use_all_available_gpus_ else args.tensor_parallel_size_
-    assert tensor_parallel_size > 0 and tensor_parallel_size <= num_available_gpus(
-    )
+    tensor_parallel_size = num_available_gpus() \
+        if args.use_all_available_gpus_ else args.tensor_parallel_size_
+    assert tensor_parallel_size > 0 and \
+           tensor_parallel_size <= num_available_gpus()
     return tensor_parallel_size
 
 

--- a/neuralmagic/benchmarks/scripts/benchmark_throughput.py
+++ b/neuralmagic/benchmarks/scripts/benchmark_throughput.py
@@ -135,7 +135,11 @@ def main(args: argparse.Namespace):
         # Setup
         current_dt = datetime.now().strftime("%Y%m%d-%H%M%S")
         result_json = instantiate_benchmark_results_dict(
-            Path(__file__).name, get_tensor_parallel_size(args))
+            benchmarking_script_name=Path(__file__).name,
+            tensor_parallel_size=get_tensor_parallel_size(args),
+            model=args.model,
+            tokenizer=args.tokenizer,
+            dataset=args.dataset)
         result_json["date"] = current_dt
         result_json["script_args"] = vars(args)
         result_json["request_throughput"] = request_throughput

--- a/neuralmagic/benchmarks/scripts/common.py
+++ b/neuralmagic/benchmarks/scripts/common.py
@@ -184,15 +184,13 @@ def warmup_server(server_host: int,
     asyncio.run(process_requests(requests))
 
 
-"""
-instantiate_benchmark_results_dict populates an empty dict with all the must-have
-key-value pairs. These are the key-value pairs that the scripts that process
-the benchmark results rely on.
-"""
-
-
 def instantiate_benchmark_results_dict(benchmarking_script_name: str,
                                        tensor_parallel_size: int) -> dict:
+    """
+    instantiate_benchmark_results_dict populates an empty dict with all the must-have
+    key-value pairs. These are the key-value pairs that the scripts that process
+    the benchmark results rely on.
+    """
     result_dict = {}
     result_dict['script_name'] = benchmarking_script_name
     result_dict['benchmarking_context'] = get_benchmarking_context()

--- a/neuralmagic/benchmarks/scripts/common.py
+++ b/neuralmagic/benchmarks/scripts/common.py
@@ -4,7 +4,7 @@ Common functions used in all benchmarking scripts
 import json
 import random
 import asyncio
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 from pathlib import Path
 from transformers import PreTrainedTokenizerBase
 
@@ -185,7 +185,9 @@ def warmup_server(server_host: int,
 
 
 def instantiate_benchmark_results_dict(benchmarking_script_name: str,
-                                       tensor_parallel_size: int) -> dict:
+                                       tensor_parallel_size: int, model: str,
+                                       tokenizer: Optional[str],
+                                       dataset: Optional[str]) -> dict:
     """
     instantiate_benchmark_results_dict populates an empty dict with all the must-have
     key-value pairs. These are the key-value pairs that the scripts that process
@@ -195,6 +197,10 @@ def instantiate_benchmark_results_dict(benchmarking_script_name: str,
     result_dict['script_name'] = benchmarking_script_name
     result_dict['benchmarking_context'] = get_benchmarking_context()
     result_dict['tensor_parallel_size'] = tensor_parallel_size
+    result_dict['model'] = model
+    result_dict['tokenizer'] = tokenizer if tokenizer is not None else model
+    result_dict['dataset'] = dataset if dataset is not None else "synthetic"
+
     return result_dict
 
 

--- a/neuralmagic/benchmarks/scripts/common.py
+++ b/neuralmagic/benchmarks/scripts/common.py
@@ -21,7 +21,7 @@ def num_available_gpus() -> int:
     return torch.cuda.device_count()
 
 
-def get_bench_environment() -> dict:
+def get_benchmarking_context() -> dict:
     """
     Return the current python version, pytorch version and CUDA version as a dict
     """
@@ -32,11 +32,15 @@ def get_bench_environment() -> dict:
         torch.cuda.get_device_properties(dev_idx)
         for dev_idx in range(torch.cuda.device_count())
     ]
+
+    cuda_device_names = [cuda_device.name for cuda_device in cuda_devices]
+
     return {
         "python_version": f"{sys.version}",
         "torch_version": f"{torch.__version__}",
         "torch_cuda_version": f"{torch.version.cuda}",
         "cuda_devices": f"{cuda_devices}"
+        "cuda_device_names" : f"{cuda_device_names}"
     }
 
 
@@ -179,6 +183,18 @@ def warmup_server(server_host: int,
                                num_output_tokens=num_output_tokens)
     asyncio.run(process_requests(requests))
 
+"""
+instantiate_benchmark_results_dict populates an empty dict with all the must-have
+key-value pairs. These are the key-value pairs that the scripts that process
+the benchmark results rely on.
+"""
+def instantiate_benchmark_results_dict(benchmarking_script_name: str,
+                                       tensor_parallel_size: int) -> dict:
+    result_dict = {}
+    result_dict['script_name'] = benchmarking_script_name
+    result_dict['benchmarking_context'] = get_benchmarking_context()
+    result_dict['tensor_parallel_size'] = tensor_parallel_size
+    return result_dict
 
 def print_benchmark_io(results: List[RequestOutput]) -> None:
     for result in results:

--- a/neuralmagic/benchmarks/scripts/common.py
+++ b/neuralmagic/benchmarks/scripts/common.py
@@ -39,8 +39,8 @@ def get_benchmarking_context() -> dict:
         "python_version": f"{sys.version}",
         "torch_version": f"{torch.__version__}",
         "torch_cuda_version": f"{torch.version.cuda}",
-        "cuda_devices": f"{cuda_devices}"
-        "cuda_device_names" : f"{cuda_device_names}"
+        "cuda_devices": f"{cuda_devices}",
+        "cuda_device_names": f"{cuda_device_names}"
     }
 
 
@@ -183,11 +183,14 @@ def warmup_server(server_host: int,
                                num_output_tokens=num_output_tokens)
     asyncio.run(process_requests(requests))
 
+
 """
 instantiate_benchmark_results_dict populates an empty dict with all the must-have
 key-value pairs. These are the key-value pairs that the scripts that process
 the benchmark results rely on.
 """
+
+
 def instantiate_benchmark_results_dict(benchmarking_script_name: str,
                                        tensor_parallel_size: int) -> dict:
     result_dict = {}
@@ -195,6 +198,7 @@ def instantiate_benchmark_results_dict(benchmarking_script_name: str,
     result_dict['benchmarking_context'] = get_benchmarking_context()
     result_dict['tensor_parallel_size'] = tensor_parallel_size
     return result_dict
+
 
 def print_benchmark_io(results: List[RequestOutput]) -> None:
     for result in results:

--- a/neuralmagic/benchmarks/scripts/common.py
+++ b/neuralmagic/benchmarks/scripts/common.py
@@ -16,17 +16,27 @@ from neuralmagic.benchmarks.datasets_registry import SHAREGPT_PATH, SHAREGPT_DOW
 from neuralmagic.benchmarks.scripts.backend_request_func import RequestFuncInput, async_request_vllm
 
 
+def num_available_gpus() -> int:
+    import torch
+    return torch.cuda.device_count()
+
+
 def get_bench_environment() -> dict:
     """
     Return the current python version, pytorch version and CUDA version as a dict
     """
     import sys
     import torch
+
+    cuda_devices = [
+        torch.cuda.get_device_properties(dev_idx)
+        for dev_idx in range(torch.cuda.device_count())
+    ]
     return {
         "python_version": f"{sys.version}",
         "torch_version": f"{torch.__version__}",
         "torch_cuda_version": f"{torch.version.cuda}",
-        "cuda_device(0)": f"{torch.cuda.get_device_properties(0)}"
+        "cuda_devices": f"{cuda_devices}"
     }
 
 


### PR DESCRIPTION
SUMMARY:
 -  Add tensor_parallel_size arg for multi-gpu benchmarking.
 -  Update the benchmark config files to use all available gpus by default.
 - Other minor changes : 
   - Fix script args outer-product enumeration.
   - Limit dataset sample-space when using sharegpt dataset.
   - Remove redundant benchmarks.
   - Standardize benchmarking result JSON.

TEST PLAN:
Run manual benchmark jobs 
multi-gpu benchmark : https://github.com/neuralmagic/nm-vllm/actions/runs/8086009234/job/22094787943 
single-gpu benchmark : https://github.com/neuralmagic/nm-vllm/actions/runs/8086016169/job/22094812742
(Then benchmarks didn't run to completion as huggingface went down mid-way. but the artifacts seem reasonable for what it did run)

