### PR TITLE
Add `nm-vllm[sparse]`+`nm-vllm[sparsity]` extras, move version to `0.1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,14 @@
 
 `nm-vllm` is a Python library that contained pre-compiled C++ and CUDA (12.1) binaries.
 
-Install it using pip (coming soon):
+Install it using pip:
 ```bash
 pip install nm-vllm
+```
+
+In order to use the weight-sparsity kernels, like through `sparsity="sparse_w16a16"`, install the extras using:
+```bash
+pip install nm-vllm[sparsity]
 ```
 
 You can also build and install `nm-vllm` from source (this will take ~10 minutes):
@@ -18,11 +23,6 @@ You can also build and install `nm-vllm` from source (this will take ~10 minutes
 git clone https://github.com/neuralmagic/nm-vllm.git
 cd nm-vllm
 pip install -e .
-```
-
-In order to use the weight-sparsity kernels, like through `sparsity="sparse_w16a16"`, you must also install `magic_wand`:
-```bash
-pip install magic_wand
 ```
 
 ## Quickstart

--- a/setup.py
+++ b/setup.py
@@ -439,7 +439,7 @@ def get_requirements() -> List[str]:
 _sparsity_deps = ["magic_wand"]
 
 
-def get_extra_requirements() -> Dict:
+def get_extra_requirements() -> dict:
     return {
         "sparse": _sparsity_deps,
         "sparsity": _sparsity_deps,

--- a/setup.py
+++ b/setup.py
@@ -435,6 +435,14 @@ def get_requirements() -> List[str]:
             requirements = f.read().strip().split("\n")
     return requirements
 
+_sparsity_deps = ["magic_wand"]
+
+def get_extra_requirements() -> Dict:
+    return {
+        "sparse": _sparsity_deps,
+        "sparsity": _sparsity_deps,
+    }
+
 
 package_data = {"vllm": ["py.typed"]}
 if os.environ.get("VLLM_USE_PRECOMPILED"):
@@ -468,6 +476,7 @@ setuptools.setup(
                                                "examples", "tests")),
     python_requires=">=3.8",
     install_requires=get_requirements(),
+    extras_require=get_extra_requirements(),
     ext_modules=ext_modules,
     cmdclass={"build_ext": BuildExtension} if not _is_neuron() else {},
     package_data=package_data,

--- a/setup.py
+++ b/setup.py
@@ -435,7 +435,9 @@ def get_requirements() -> List[str]:
             requirements = f.read().strip().split("\n")
     return requirements
 
+
 _sparsity_deps = ["magic_wand"]
+
 
 def get_extra_requirements() -> Dict:
     return {

--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -8,7 +8,7 @@ from vllm.entrypoints.llm import LLM
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import SamplingParams
 
-__version__ = "0.3.2"
+__version__ = "0.1.0"
 
 __all__ = [
     "LLM",


### PR DESCRIPTION
Now you can use `pip install nm-vllm[sparse]` to install everything.

This also moves the versioning to our separate tag