### PR TITLE
turn off single gpu scenario

### DIFF
--- a/.github/workflows/remote-push.yml
+++ b/.github/workflows/remote-push.yml
@@ -26,17 +26,3 @@ jobs:
             Gi_per_thread: 4
             python: ${{ matrix.python }}
         secrets: inherit
-
-    # single gpu
-    AWS-AVX2-32G-A10G-24G:
-        strategy:
-            matrix:
-                python: [3.11.4]
-        uses: ./.github/workflows/build-test.yml
-        with:
-            label: aws-avx2-32G-a10g-24G
-            timeout: 180
-            gitref: '${{ github.ref }}'
-            Gi_per_thread: 12
-            python: ${{ matrix.python }}
-        secrets: inherit


### PR DESCRIPTION
SUMMARY:
* turn off single gpu scenario testing, since it takes longer than 3 hours to run

TEST PLAN:
runs on remote push
