### PR TITLE
Benchmarking : update Gi_per_thread

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,7 @@ jobs:
             benchmark_config_list_file:  ./.github/data/nm_benchmark_configs_list.txt
             timeout: 240
             gitref: '${{ github.ref }}'
+            Gi_per_thread: 4
             python: "3.10.12"
         secrets: inherit
 
@@ -28,5 +29,6 @@ jobs:
             benchmark_config_list_file:  ./.github/data/nm_benchmark_configs_list.txt
             timeout: 240
             gitref: '${{ github.ref }}'
+            Gi_per_thread: 12
             python: "3.10.12"
         secrets: inherit

--- a/.github/workflows/nm-benchmark.yml
+++ b/.github/workflows/nm-benchmark.yml
@@ -19,6 +19,10 @@ on:
         description: "git commit hash or branch name"
         type: string
         required: true
+      Gi_per_thread:
+        description: 'requested GiB to reserve per thread'
+        type: string
+        required: true
       python:
         description: "python version, e.g. 3.10.12"
         type: string
@@ -41,6 +45,10 @@ on:
         required: true
       gitref:
         description: "git commit hash or branch name"
+        type: string
+        required: true
+      Gi_per_thread:
+        description: 'requested GiB to reserve per thread'
         type: string
         required: true
       python:
@@ -67,7 +75,7 @@ jobs:
         uses: ./.github/actions/nm-set-env/
         with:
           hf_token: ${{ secrets.NM_HF_TOKEN }}
-          Gi_per_thread: 4
+          Gi_per_thread: ${{ inputs.Gi_per_thread }}
 
       - name: set python
         id: set_python
@@ -86,7 +94,7 @@ jobs:
         id: build
         uses: ./.github/actions/nm-build-vllm/
         with:
-          Gi_per_thread: 4
+          Gi_per_thread: ${{ inputs.Gi_per_thread }}
           python: ${{ inputs.python }}
           venv: TEST
           pypi: ${{ secrets.NM_PRIVATE_PYPI_LOCATION }}


### PR DESCRIPTION
SUMMARY:
Single GPU A10g instance fails with the default of `Gi_per_thread = 4`. 
Pass Gi_per_thread as an input to the nm-benchmark workflow and set it to 12 for the single GPU A10g instance


TEST PLAN:
Manual testing
