### PR TITLE
skipped test for nightly failure

### DIFF
--- a/tests/entrypoints/test_openai_server.py
+++ b/tests/entrypoints/test_openai_server.py
@@ -549,7 +549,12 @@ async def test_guided_regex_completion(server, client: openai.AsyncOpenAI):
         assert completion.choices[i].text is not None
         assert re.fullmatch(TEST_REGEX, completion.choices[i].text) is not None
 
-
+# *** UPSTREAM SYNC ***
+# This test covers an experimental feature in vLLM, guided generation.
+# Currently, there is an upstream issue being debugged
+# See: https://github.com/vllm-project/vllm/pull/3383
+# Once this is resolved upstream, turn the test back on.
+@pytest.mark.skip("Issue upstream, currently being resolved.")
 async def test_guided_regex_chat(server, client: openai.AsyncOpenAI):
     messages = [{
         "role": "system",

--- a/tests/entrypoints/test_openai_server.py
+++ b/tests/entrypoints/test_openai_server.py
@@ -534,6 +534,7 @@ async def test_guided_json_chat(server, client: openai.AsyncOpenAI):
     assert json1["name"] != json2["name"]
     assert json1["age"] != json2["age"]
 
+
 async def test_guided_regex_completion(server, client: openai.AsyncOpenAI):
     completion = await client.completions.create(
         model=MODEL_NAME,
@@ -548,6 +549,7 @@ async def test_guided_regex_completion(server, client: openai.AsyncOpenAI):
     for i in range(3):
         assert completion.choices[i].text is not None
         assert re.fullmatch(TEST_REGEX, completion.choices[i].text) is not None
+
 
 # *** UPSTREAM SYNC ***
 # This test covers an experimental feature in vLLM, guided generation.


### PR DESCRIPTION
SUMMARY:
Skips test causing nightly failure for the short term
- https://github.com/neuralmagic/nm-vllm/actions/runs/8257372912/job/22587806623#step:9:1296

Issue is related to an experimental feature called guided generation. Upstream team is working on resolving via https://github.com/vllm-project/vllm/pull/3383.

Change will cause merge conflicts with upstream. During next upstream sync where they have fixed the issue, we can turn this test back on

TEST PLAN:
Automation

