### PR TITLE
Benchmark : Update benchmark configs for Nightly

### DIFF
--- a/.github/data/nm_benchmark_nightly_configs_list.txt
+++ b/.github/data/nm_benchmark_nightly_configs_list.txt
@@ -1,3 +1,5 @@
 neuralmagic/benchmarks/configs/benchmark_serving.json
 neuralmagic/benchmarks/configs/benchmark_throughput.json
+neuralmagic/benchmarks/configs/benchmark_throughput_decode.json
+neuralmagic/benchmarks/configs/benchmark_throughput_prefill.json
 neuralmagic/benchmarks/configs/benchmark_remote_push.json

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,7 @@ jobs:
         with:
             label: aws-avx2-192G-4-a10g-96G
             benchmark_config_list_file:  ./.github/data/nm_benchmark_nightly_configs_list.txt
-            timeout: 240
+            timeout: 480
             gitref: '${{ github.ref }}'
             Gi_per_thread: 4
             python: "3.10.12"
@@ -49,7 +49,7 @@ jobs:
         with:
             label: aws-avx2-32G-a10g-24G
             benchmark_config_list_file:  ./.github/data/nm_benchmark_nightly_configs_list.txt
-            timeout: 240
+            timeout: 720
             gitref: '${{ github.ref }}'
             Gi_per_thread: 12
             python: "3.10.12"

--- a/neuralmagic/benchmarks/configs/benchmark_remote_push.json
+++ b/neuralmagic/benchmarks/configs/benchmark_remote_push.json
@@ -1,23 +1,25 @@
 {
 	"configs": [
 		{
-			"description": "Benchmark vllm engine throughput - synthetic",
+			"description": "VLLM Engine throughput - synthetic",
 			"models": [
 				"NousResearch/Llama-2-7b-chat-hf"
 			],
-			"max_model_lens" : [4096],
+			"max_model_lens": [
+				4096
+			],
 			"script_name": "benchmark_throughput",
 			"script_args": {
-                                "input-len" : [
-                                        256
-                                ],
+				"input-len": [
+					256
+				],
 				"output-len": [
 					128
 				],
 				"num-prompts": [
 					1000
 				],
-				"use-all-available-gpus_" : []
+				"use-all-available-gpus_": []
 			}
 		}
 	]

--- a/neuralmagic/benchmarks/configs/benchmark_serving.json
+++ b/neuralmagic/benchmarks/configs/benchmark_serving.json
@@ -28,7 +28,7 @@
 			}
 		},
                 {
-			"description": "Benchmark vllm serving - Sparse",
+			"description": "VLLM Serving - Sparse",
 			"models": [
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50"
 			],
@@ -52,7 +52,7 @@
 			}
 		},
                 {
-			"description": "Benchmark vllm serving - 2:4 Sparse",
+			"description": "VLLM Serving - 2:4 Sparse",
 			"models": [
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4"
 			],

--- a/neuralmagic/benchmarks/configs/benchmark_serving.json
+++ b/neuralmagic/benchmarks/configs/benchmark_serving.json
@@ -1,12 +1,12 @@
 {
 	"configs": [
 		{
-			"description": "VLLM Serving",
+			"description": "VLLM Serving - Dense",
 			"models": [
-				"facebook/opt-125m",
-				"TinyLlama/TinyLlama-1.1B-Chat-v1.0",
-				"mistralai/Mistral-7B-Instruct-v0.2",
-				"NousResearch/Llama-2-7b-chat-hf"
+                          "teknium/OpenHermes-2.5-Mistral-7B",
+                          "NousResearch/Llama-2-7b-chat-hf",
+                          "neuralmagic/OpenHermes-2.5-Mistral-7B-marlin",
+                          "TheBloke/OpenHermes-2.5-Mistral-7B-GPTQ"
 			],
 			"use_all_available_gpus" : "",
 			"max_model_lens": [
@@ -16,13 +16,59 @@
 			"script_name": "benchmark_serving",
 			"script_args": {
 				"nr-qps-pair_": [
-					"50,0.5",
-					"100,1",
-					"200,2",
-					"500,5"
+                                        "150,0.5",
+                                        "300,1",
+                                        "750,2.5",
+                                        "1500,5",
+                                        "3000,10"
 				],
-				"best-of": [
-					1
+				"dataset": [
+					"sharegpt"
+				]
+			}
+		},
+                {
+			"description": "Benchmark vllm serving - Sparse",
+			"models": [
+                          "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50"
+			],
+			"use_all_available_gpus" : "",
+			"max_model_lens": [
+				4096
+			],
+			"sparsity": ["sparse_w16a16"],
+			"script_name": "benchmark_serving",
+			"script_args": {
+				"nr-qps-pair_": [
+                                        "150,0.5",
+                                        "300,1",
+                                        "750,2.5",
+                                        "1500,5",
+                                        "3000,10"
+				],
+				"dataset": [
+					"sharegpt"
+				]
+			}
+		},
+                {
+			"description": "Benchmark vllm serving - 2:4 Sparse",
+			"models": [
+                          "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4"
+			],
+			"use_all_available_gpus" : "",
+			"max_model_lens": [
+				4096
+			],
+			"sparsity": ["semi_structured_sparse_w16a16"],
+			"script_name": "benchmark_serving",
+			"script_args": {
+				"nr-qps-pair_": [
+                                        "150,0.5",
+                                        "300,1",
+                                        "750,2.5",
+                                        "1500,5",
+                                        "3000,10"
 				],
 				"dataset": [
 					"sharegpt"

--- a/neuralmagic/benchmarks/configs/benchmark_throughput.json
+++ b/neuralmagic/benchmarks/configs/benchmark_throughput.json
@@ -24,7 +24,7 @@
 			}
 		},
 		{
-			"description": "Benchmark vllm engine throughput - with dataset - Sparse",
+			"description": "VLLM Engine throughput - Sparse (with dataset)",
 			"models": [
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50"
 			],
@@ -45,7 +45,7 @@
 			}
 		},
 		{
-			"description": "Benchmark vllm engine throughput - with dataset - 2:4 Sparse",
+			"description": "VLLM Engine throughput - 2:4 Sparse (with dataset)",
 			"models": [
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4"
 			],

--- a/neuralmagic/benchmarks/configs/benchmark_throughput.json
+++ b/neuralmagic/benchmarks/configs/benchmark_throughput.json
@@ -3,12 +3,14 @@
 		{
 			"description": "VLLM Engine throughput - Dense (with dataset)",
 			"models": [
-                          "teknium/OpenHermes-2.5-Mistral-7B",
-                          "neuralmagic/OpenHermes-2.5-Mistral-7B-marlin",
-                          "TheBloke/OpenHermes-2.5-Mistral-7B-GPTQ",
-                          "NousResearch/Llama-2-7b-chat-hf"
+				"teknium/OpenHermes-2.5-Mistral-7B",
+				"neuralmagic/OpenHermes-2.5-Mistral-7B-marlin",
+				"TheBloke/OpenHermes-2.5-Mistral-7B-GPTQ",
+				"NousResearch/Llama-2-7b-chat-hf"
 			],
-			"max_model_lens" : [4096],
+			"max_model_lens": [
+				4096
+			],
 			"script_name": "benchmark_throughput",
 			"script_args": {
 				"dataset": [
@@ -20,15 +22,17 @@
 				"num-prompts": [
 					1000
 				],
-				"use-all-available-gpus_" : []
+				"use-all-available-gpus_": []
 			}
 		},
 		{
 			"description": "VLLM Engine throughput - Sparse (with dataset)",
 			"models": [
-                          "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50"
+				"neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50"
 			],
-			"max_model_lens" : [4096],
+			"max_model_lens": [
+				4096
+			],
 			"script_name": "benchmark_throughput",
 			"script_args": {
 				"dataset": [
@@ -40,16 +44,20 @@
 				"num-prompts": [
 					1000
 				],
-			        "sparsity": ["sparse_w16a16"],
-				"use-all-available-gpus_" : []
+				"sparsity": [
+					"sparse_w16a16"
+				],
+				"use-all-available-gpus_": []
 			}
 		},
 		{
 			"description": "VLLM Engine throughput - 2:4 Sparse (with dataset)",
 			"models": [
-                          "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4"
+				"neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4"
 			],
-			"max_model_lens" : [4096],
+			"max_model_lens": [
+				4096
+			],
 			"script_name": "benchmark_throughput",
 			"script_args": {
 				"dataset": [
@@ -61,8 +69,10 @@
 				"num-prompts": [
 					1000
 				],
-			        "sparsity": ["semi_structured_sparse_w16a16"],
-				"use-all-available-gpus_" : []
+				"sparsity": [
+					"semi_structured_sparse_w16a16"
+				],
+				"use-all-available-gpus_": []
 			}
 		}
 	]

--- a/neuralmagic/benchmarks/configs/benchmark_throughput_decode.json
+++ b/neuralmagic/benchmarks/configs/benchmark_throughput_decode.json
@@ -1,7 +1,7 @@
 {
 	"configs": [
 		{
-			"description": "VLLM Engine throughput - Dense (with dataset)",
+			"description": "Benchmark vllm engine decode throughput - synthetic - Dense",
 			"models": [
                           "teknium/OpenHermes-2.5-Mistral-7B",
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-marlin",
@@ -11,59 +11,74 @@
 			"max_model_lens" : [4096],
 			"script_name": "benchmark_throughput",
 			"script_args": {
-				"dataset": [
-					"sharegpt"
+				"input-len": [
+					2
 				],
 				"output-len": [
 					128
 				],
 				"num-prompts": [
-					1000
+					1,
+					4,
+					8,
+					16,
+					32,
+					64
 				],
 				"use-all-available-gpus_" : []
 			}
 		},
 		{
-			"description": "Benchmark vllm engine throughput - with dataset - Sparse",
+			"description": "Benchmark vllm engine decode throughput - synthetic - Sparse",
 			"models": [
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50"
 			],
 			"max_model_lens" : [4096],
 			"script_name": "benchmark_throughput",
 			"script_args": {
-				"dataset": [
-					"sharegpt"
+				"input-len": [
+					2
 				],
 				"output-len": [
 					128
 				],
 				"num-prompts": [
-					1000
+					1,
+					4,
+					8,
+					16,
+					32,
+					64
 				],
 			        "sparsity": ["sparse_w16a16"],
 				"use-all-available-gpus_" : []
 			}
 		},
 		{
-			"description": "Benchmark vllm engine throughput - with dataset - 2:4 Sparse",
+			"description": "Benchmark vllm engine decode throughput - synthetic - 2:4 Sparse",
 			"models": [
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4"
 			],
 			"max_model_lens" : [4096],
 			"script_name": "benchmark_throughput",
 			"script_args": {
-				"dataset": [
-					"sharegpt"
+				"input-len": [
+					2
 				],
 				"output-len": [
 					128
 				],
 				"num-prompts": [
-					1000
+					1,
+					4,
+					8,
+					16,
+					32,
+					64
 				],
 			        "sparsity": ["semi_structured_sparse_w16a16"],
 				"use-all-available-gpus_" : []
 			}
 		}
-	]
+        ]
 }

--- a/neuralmagic/benchmarks/configs/benchmark_throughput_decode.json
+++ b/neuralmagic/benchmarks/configs/benchmark_throughput_decode.json
@@ -3,12 +3,14 @@
 		{
 			"description": "VLLM Engine decode throughput - Dense (synthetic)",
 			"models": [
-                          "teknium/OpenHermes-2.5-Mistral-7B",
-                          "neuralmagic/OpenHermes-2.5-Mistral-7B-marlin",
-                          "TheBloke/OpenHermes-2.5-Mistral-7B-GPTQ",
-                          "NousResearch/Llama-2-7b-chat-hf"
+				"teknium/OpenHermes-2.5-Mistral-7B",
+				"neuralmagic/OpenHermes-2.5-Mistral-7B-marlin",
+				"TheBloke/OpenHermes-2.5-Mistral-7B-GPTQ",
+				"NousResearch/Llama-2-7b-chat-hf"
 			],
-			"max_model_lens" : [4096],
+			"max_model_lens": [
+				4096
+			],
 			"script_name": "benchmark_throughput",
 			"script_args": {
 				"input-len": [
@@ -25,15 +27,17 @@
 					32,
 					64
 				],
-				"use-all-available-gpus_" : []
+				"use-all-available-gpus_": []
 			}
 		},
 		{
 			"description": "VLLM Engine decode throughput - Sparse (synthetic)",
 			"models": [
-                          "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50"
+				"neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50"
 			],
-			"max_model_lens" : [4096],
+			"max_model_lens": [
+				4096
+			],
 			"script_name": "benchmark_throughput",
 			"script_args": {
 				"input-len": [
@@ -50,16 +54,20 @@
 					32,
 					64
 				],
-			        "sparsity": ["sparse_w16a16"],
-				"use-all-available-gpus_" : []
+				"sparsity": [
+					"sparse_w16a16"
+				],
+				"use-all-available-gpus_": []
 			}
 		},
 		{
 			"description": "VLLM Engine decode throughput - 2:4 Sparse (synthetic)",
 			"models": [
-                          "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4"
+				"neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4"
 			],
-			"max_model_lens" : [4096],
+			"max_model_lens": [
+				4096
+			],
 			"script_name": "benchmark_throughput",
 			"script_args": {
 				"input-len": [
@@ -76,9 +84,11 @@
 					32,
 					64
 				],
-			        "sparsity": ["semi_structured_sparse_w16a16"],
-				"use-all-available-gpus_" : []
+				"sparsity": [
+					"semi_structured_sparse_w16a16"
+				],
+				"use-all-available-gpus_": []
 			}
 		}
-        ]
+	]
 }

--- a/neuralmagic/benchmarks/configs/benchmark_throughput_decode.json
+++ b/neuralmagic/benchmarks/configs/benchmark_throughput_decode.json
@@ -1,7 +1,7 @@
 {
 	"configs": [
 		{
-			"description": "Benchmark vllm engine decode throughput - synthetic - Dense",
+			"description": "VLLM Engine decode throughput - Dense (synthetic)",
 			"models": [
                           "teknium/OpenHermes-2.5-Mistral-7B",
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-marlin",
@@ -29,7 +29,7 @@
 			}
 		},
 		{
-			"description": "Benchmark vllm engine decode throughput - synthetic - Sparse",
+			"description": "VLLM Engine decode throughput - Sparse (synthetic)",
 			"models": [
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50"
 			],
@@ -55,7 +55,7 @@
 			}
 		},
 		{
-			"description": "Benchmark vllm engine decode throughput - synthetic - 2:4 Sparse",
+			"description": "VLLM Engine decode throughput - 2:4 Sparse (synthetic)",
 			"models": [
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4"
 			],

--- a/neuralmagic/benchmarks/configs/benchmark_throughput_prefill.json
+++ b/neuralmagic/benchmarks/configs/benchmark_throughput_prefill.json
@@ -1,7 +1,7 @@
 {
 	"configs": [
 		{
-			"description": "VLLM Engine throughput - Dense (with dataset)",
+			"description": "Benchmark vllm engine prefill throughput - synthetic - Dense",
 			"models": [
                           "teknium/OpenHermes-2.5-Mistral-7B",
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-marlin",
@@ -11,59 +11,80 @@
 			"max_model_lens" : [4096],
 			"script_name": "benchmark_throughput",
 			"script_args": {
-				"dataset": [
-					"sharegpt"
+				"input-len": [
+					16,
+					32,
+					64,
+					128,
+					256,
+					512,
+					1024,
+                                        2048
 				],
 				"output-len": [
-					128
+					1
 				],
 				"num-prompts": [
-					1000
+					1
 				],
 				"use-all-available-gpus_" : []
 			}
 		},
 		{
-			"description": "Benchmark vllm engine throughput - with dataset - Sparse",
+			"description": "Benchmark vllm engine prefill throughput - synthetic - Sparse",
 			"models": [
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50"
 			],
 			"max_model_lens" : [4096],
 			"script_name": "benchmark_throughput",
 			"script_args": {
-				"dataset": [
-					"sharegpt"
+				"input-len": [
+					16,
+					32,
+					64,
+					128,
+					256,
+					512,
+					1024,
+                                        2048
 				],
 				"output-len": [
-					128
+					1
 				],
 				"num-prompts": [
-					1000
+					1
 				],
 			        "sparsity": ["sparse_w16a16"],
 				"use-all-available-gpus_" : []
 			}
 		},
 		{
-			"description": "Benchmark vllm engine throughput - with dataset - 2:4 Sparse",
+			"description": "Benchmark vllm engine prefill throughput - synthetic - 2:4 Sparse",
 			"models": [
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4"
 			],
 			"max_model_lens" : [4096],
 			"script_name": "benchmark_throughput",
 			"script_args": {
-				"dataset": [
-					"sharegpt"
+				"input-len": [
+					16,
+					32,
+					64,
+					128,
+					256,
+					512,
+					1024,
+                                        2048
 				],
 				"output-len": [
-					128
+					1
 				],
 				"num-prompts": [
-					1000
+					1
 				],
 			        "sparsity": ["semi_structured_sparse_w16a16"],
 				"use-all-available-gpus_" : []
 			}
 		}
-	]
+        ]
 }

--- a/neuralmagic/benchmarks/configs/benchmark_throughput_prefill.json
+++ b/neuralmagic/benchmarks/configs/benchmark_throughput_prefill.json
@@ -3,12 +3,14 @@
 		{
 			"description": "VLLM Engine prefill throughput - Dense (synthetic)",
 			"models": [
-                          "teknium/OpenHermes-2.5-Mistral-7B",
-                          "neuralmagic/OpenHermes-2.5-Mistral-7B-marlin",
-                          "TheBloke/OpenHermes-2.5-Mistral-7B-GPTQ",
-                          "NousResearch/Llama-2-7b-chat-hf"
+				"teknium/OpenHermes-2.5-Mistral-7B",
+				"neuralmagic/OpenHermes-2.5-Mistral-7B-marlin",
+				"TheBloke/OpenHermes-2.5-Mistral-7B-GPTQ",
+				"NousResearch/Llama-2-7b-chat-hf"
 			],
-			"max_model_lens" : [4096],
+			"max_model_lens": [
+				4096
+			],
 			"script_name": "benchmark_throughput",
 			"script_args": {
 				"input-len": [
@@ -19,7 +21,7 @@
 					256,
 					512,
 					1024,
-                                        2048
+					2048
 				],
 				"output-len": [
 					1
@@ -27,15 +29,17 @@
 				"num-prompts": [
 					1
 				],
-				"use-all-available-gpus_" : []
+				"use-all-available-gpus_": []
 			}
 		},
 		{
 			"description": "VLLM Engine prefill throughput - Sparse (synthetic)",
 			"models": [
-                          "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50"
+				"neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50"
 			],
-			"max_model_lens" : [4096],
+			"max_model_lens": [
+				4096
+			],
 			"script_name": "benchmark_throughput",
 			"script_args": {
 				"input-len": [
@@ -46,7 +50,7 @@
 					256,
 					512,
 					1024,
-                                        2048
+					2048
 				],
 				"output-len": [
 					1
@@ -54,16 +58,20 @@
 				"num-prompts": [
 					1
 				],
-			        "sparsity": ["sparse_w16a16"],
-				"use-all-available-gpus_" : []
+				"sparsity": [
+					"sparse_w16a16"
+				],
+				"use-all-available-gpus_": []
 			}
 		},
 		{
 			"description": "VLLM Engine prefill throughput - 2:4 Sparse (synthetic)",
 			"models": [
-                          "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4"
+				"neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4"
 			],
-			"max_model_lens" : [4096],
+			"max_model_lens": [
+				4096
+			],
 			"script_name": "benchmark_throughput",
 			"script_args": {
 				"input-len": [
@@ -74,7 +82,7 @@
 					256,
 					512,
 					1024,
-                                        2048
+					2048
 				],
 				"output-len": [
 					1
@@ -82,9 +90,11 @@
 				"num-prompts": [
 					1
 				],
-			        "sparsity": ["semi_structured_sparse_w16a16"],
-				"use-all-available-gpus_" : []
+				"sparsity": [
+					"semi_structured_sparse_w16a16"
+				],
+				"use-all-available-gpus_": []
 			}
 		}
-        ]
+	]
 }

--- a/neuralmagic/benchmarks/configs/benchmark_throughput_prefill.json
+++ b/neuralmagic/benchmarks/configs/benchmark_throughput_prefill.json
@@ -1,7 +1,7 @@
 {
 	"configs": [
 		{
-			"description": "Benchmark vllm engine prefill throughput - synthetic - Dense",
+			"description": "VLLM Engine prefill throughput - Dense (synthetic)",
 			"models": [
                           "teknium/OpenHermes-2.5-Mistral-7B",
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-marlin",
@@ -31,7 +31,7 @@
 			}
 		},
 		{
-			"description": "Benchmark vllm engine prefill throughput - synthetic - Sparse",
+			"description": "VLLM Engine prefill throughput - Sparse (synthetic)",
 			"models": [
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50"
 			],
@@ -59,7 +59,7 @@
 			}
 		},
 		{
-			"description": "Benchmark vllm engine prefill throughput - synthetic - 2:4 Sparse",
+			"description": "VLLM Engine prefill throughput - 2:4 Sparse (synthetic)",
 			"models": [
                           "neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4"
 			],

--- a/neuralmagic/benchmarks/configs/minimal_test.json
+++ b/neuralmagic/benchmarks/configs/minimal_test.json
@@ -3,16 +3,18 @@
 		{
 			"description": "Benchmark vllm serving",
 			"models": [
-                          "mistralai/Mistral-7B-Instruct-v0.2"
+				"mistralai/Mistral-7B-Instruct-v0.2"
 			],
-			"use_all_available_gpus" : "",
+			"use_all_available_gpus": "",
 			"max_model_lens": [
 				4096
 			],
 			"sparsity": [],
 			"script_name": "benchmark_serving",
 			"script_args": {
-                                "nr-qps-pair_" : ["5,inf"],
+				"nr-qps-pair_": [
+					"5,inf"
+				],
 				"dataset": [
 					"sharegpt"
 				]
@@ -21,9 +23,11 @@
 		{
 			"description": "Benchmark vllm engine throughput - with dataset",
 			"models": [
-                                "mistralai/Mistral-7B-Instruct-v0.2"
+				"mistralai/Mistral-7B-Instruct-v0.2"
 			],
-			"max_model_lens" : [4096],
+			"max_model_lens": [
+				4096
+			],
 			"script_name": "benchmark_throughput",
 			"script_args": {
 				"output-len": [
@@ -32,11 +36,13 @@
 				"num-prompts": [
 					100
 				],
-                                "dataset" : [
-                                  "sharegpt"
-                                ],
-                                "max-model-len" : [4096],
-				"use-all-available-gpus_" : []
+				"dataset": [
+					"sharegpt"
+				],
+				"max-model-len": [
+					4096
+				],
+				"use-all-available-gpus_": []
 			}
 		}
 	]

--- a/neuralmagic/benchmarks/requirements-benchmark.txt
+++ b/neuralmagic/benchmarks/requirements-benchmark.txt
@@ -2,3 +2,4 @@
 requests
 aiohttp
 datasets
+nm-magic-wand


### PR DESCRIPTION
SUMMARY:
Update the benchmark configs such that the Nightly runs the following models, 
 - `7b Mistral`
   * Base : teknium/OpenHermes-2.5-Mistral-7B 
   * GPTQ :  TheBloke/OpenHermes-2.5-Mistral-7B-GPTQ 
   * Marlin : neuralmagic/OpenHermes-2.5-Mistral-7B-marlin
   * Sparse  : neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50
   * Sparse 2:4 : neuralmagic/OpenHermes-2.5-Mistral-7B-pruned2.4 
- `Llama 7b fp16`
  * NousResearch/Llama-2-7b-chat-hf #fp16

- Update benchmark_serving num_prompts and qps pairs.
- Minor update to the benchmark_throughput prefill and decode cases.


TEST PLAN:
Manual testing
