### PR TITLE
Benchmark : Turn-off nightly multi-gpu benchmarks temporarily

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,18 +40,18 @@ jobs:
         secrets: inherit
 
     # multi-gpu
-    AWS-AVX2-192G-4-A10G-96G-Benchmark:
-        uses: ./.github/workflows/nm-benchmark.yml
-        with:
-            label: aws-avx2-192G-4-a10g-96G
-            benchmark_config_list_file:  ./.github/data/nm_benchmark_nightly_configs_list.txt
-            timeout: 480
-            gitref: '${{ github.ref }}'
-            Gi_per_thread: 4
-            python: "3.10.12"
-            # Always push if it is a scheduled job
-            push_benchmark_results_to_gh_pages: "${{ github.event_name == 'schedule' || inputs.push_benchmark_results_to_gh_pages }}"
-        secrets: inherit
+    # AWS-AVX2-192G-4-A10G-96G-Benchmark:
+    #     uses: ./.github/workflows/nm-benchmark.yml
+    #     with:
+    #         label: aws-avx2-192G-4-a10g-96G
+    #         benchmark_config_list_file:  ./.github/data/nm_benchmark_nightly_configs_list.txt
+    #         timeout: 480
+    #         gitref: '${{ github.ref }}'
+    #         Gi_per_thread: 4
+    #         python: "3.10.12"
+    #         # Always push if it is a scheduled job
+    #         push_benchmark_results_to_gh_pages: "${{ github.event_name == 'schedule' || inputs.push_benchmark_results_to_gh_pages }}"
+    #     secrets: inherit
 
     # single gpu
     AWS-AVX2-32G-A10G-24G-Benchmark:


### PR DESCRIPTION
SUMMARY:
  The nightly benchmarks run on `A10g x 4` and `A10g x 1` instances.  The `A10gx4` instance takes about 6.5 hrs and the `A10g` instance is estimated to take about 8.5 hrs. 

This PR turns-off the `A10g x 4` instance for the following reasons,
 * cut costs
 * The models we benchmark with don't use a `A10g x 4` in a realistic scenario.

The `A10g x 4` instance shouldn't take `6.5` hrs to run the nightly. It is likely there are optimization that we can make. This is a temporary solution until we investigate.

TEST PLAN:
No testing. 

