### PR TITLE
Delete .github/pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,0 @@
-SUMMARY:
-"please provide a brief summary"
-
-TEST PLAN:
-"please outline how the changes were tested"
-


### PR DESCRIPTION
A merge conflict left this behind and it leaves a warning on some systems
```
warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:

  '.github/PULL_REQUEST_TEMPLATE.md'
  '.github/pull_request_template.md'
  ```