### PR TITLE
Lock lm-evaluation-harness to commit 262f879

### DIFF
--- a/.github/actions/nm-lm-eval-accuracy/action.yml
+++ b/.github/actions/nm-lm-eval-accuracy/action.yml
@@ -16,7 +16,7 @@ runs:
       VENV="${{ inputs.venv }}-${COMMIT:0:7}"
       source $(pyenv root)/versions/${{ inputs.python }}/envs/${VENV}/bin/activate
 
-      pip3 install git+https://github.com/EleutherAI/lm-evaluation-harness.git
+      pip3 install git+https://github.com/EleutherAI/lm-evaluation-harness.git@262f879a06aa5de869e5dd951d0ff2cf2f9ba380
       pip3 install optimum auto-gptq
 
       SUCCESS=0


### PR DESCRIPTION
This fixes dependency issues recently introduced by adding NeMo to lm-evaluation-harness