### PR TITLE
Fix sparsity arg in Engine/ModelArgs

### DIFF
--- a/neuralmagic/tests/skip-for-remote-push.txt
+++ b/neuralmagic/tests/skip-for-remote-push.txt
@@ -12,7 +12,6 @@ tests/distributed/test_comm_ops.py
 tests/prefix_caching/test_prefix_caching.py
 tests/models/test_models_logprobs.py
 tests/models/test_models.py
-tests/models/test_compressed_memory.py
 tests/spec_decode/test_utils.py
 tests/spec_decode/test_spec_decode_worker.py
 tests/spec_decode/test_metrics.py

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -88,9 +88,9 @@ class ModelConfig:
         tokenizer_revision: Optional[str] = None,
         max_model_len: Optional[int] = None,
         quantization: Optional[str] = None,
+        quantization_param_path: Optional[str] = None,
         # UPSTREAM SYNC: keep sparsity
         sparsity: Optional[str] = None,
-        quantization_param_path: Optional[str] = None,
         enforce_eager: bool = False,
         max_context_len_to_capture: Optional[int] = None,
         max_logprobs: int = 5,
@@ -106,9 +106,9 @@ class ModelConfig:
         self.code_revision = code_revision
         self.tokenizer_revision = tokenizer_revision
         self.quantization = quantization
+        self.quantization_param_path = quantization_param_path
         # UPSTREAM SYNC: keep sparsity
         self.sparsity = sparsity
-        self.quantization_param_path = quantization_param_path
         self.enforce_eager = enforce_eager
         self.max_context_len_to_capture = max_context_len_to_capture
         self.max_logprobs = max_logprobs

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -432,12 +432,25 @@ class EngineArgs:
     def create_engine_config(self, ) -> EngineConfig:
         device_config = DeviceConfig(self.device)
         model_config = ModelConfig(
-            self.model, self.tokenizer, self.tokenizer_mode,
-            self.trust_remote_code, self.download_dir, self.load_format,
-            self.dtype, self.seed, self.revision, self.code_revision,
-            self.tokenizer_revision, self.max_model_len, self.quantization,
-            self.quantization_param_path, self.sparsity, self.enforce_eager,
-            self.max_context_len_to_capture, self.max_logprobs)
+            self.model,
+            self.tokenizer,
+            self.tokenizer_mode,
+            self.trust_remote_code,
+            self.download_dir,
+            self.load_format,
+            self.dtype,
+            self.seed,
+            self.revision,
+            self.code_revision,
+            self.tokenizer_revision,
+            self.max_model_len,
+            self.quantization,
+            self.quantization_param_path,
+            # UPSTREAM SYNC: keep sparsity argument
+            self.sparsity,
+            self.enforce_eager,
+            self.max_context_len_to_capture,
+            self.max_logprobs)
         cache_config = CacheConfig(self.block_size,
                                    self.gpu_memory_utilization,
                                    self.swap_space, self.kv_cache_dtype,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -436,7 +436,7 @@ class EngineArgs:
             self.trust_remote_code, self.download_dir, self.load_format,
             self.dtype, self.seed, self.revision, self.code_revision,
             self.tokenizer_revision, self.max_model_len, self.quantization,
-            self.quantization_param_path, self.enforce_eager,
+            self.quantization_param_path, self.sparsity, self.enforce_eager,
             self.max_context_len_to_capture, self.max_logprobs)
         cache_config = CacheConfig(self.block_size,
                                    self.gpu_memory_utilization,


### PR DESCRIPTION
The `sparsity` argument was being ignored because it was switched around with the new `quantization_param_path` arg.

```
>>> from vllm import LLM
>>> model = LLM("nm-testing/OpenHermes-2.5-Mistral-7B-pruned50", sparsity="sparse_w16a16", max_model_len=1024)
INFO 04-10 18:02:12 llm_engine.py:81] Initializing an LLM engine (v0.2.0) with config: model='nm-testing/OpenHermes-2.5-Mistral-7B-pruned50', speculative_config=None, tokenizer='nm-testing/OpenHermes-2.5-Mistral-7B-pruned50', tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=1024, download_dir=None, load_format=auto, tensor_parallel_size=1, disable_custom_all_reduce=True, quantization=None, sparsity=None, enforce_eager=8192, kv_cache_dtype=auto, quantization_param_path=False, device_config=cuda, seed=0)
```
Notice the `sparsity=None` in the log, which doesn't match the arg we specified.


Because the model config construction in `create_engine_config()` doesn't use named arguments, these args got flipped around, see the mass of:
```python
    def create_engine_config(self, ) -> EngineConfig:
        device_config = DeviceConfig(self.device)
        model_config = ModelConfig(
            self.model, self.tokenizer, self.tokenizer_mode,
            self.trust_remote_code, self.download_dir, self.load_format,
            self.dtype, self.seed, self.revision, self.code_revision,
            self.tokenizer_revision, self.max_model_len, self.quantization,
            self.quantization_param_path, self.sparsity, self.enforce_eager,
            self.max_context_len_to_capture, self.max_logprobs)
            ...
```