### PR TITLE
Prototype FP8Linear W8A8 runtime quantization

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -207,7 +207,7 @@ class ModelConfig:
                     f"({self.sparsity}).")
 
     def _verify_quantization(self) -> None:
-        supported_quantization = ["awq", "gptq", "squeezellm", "marlin"]
+        supported_quantization = ["awq", "fp8", "gptq", "squeezellm", "marlin"]
         rocm_not_supported_quantization = ["awq", "marlin"]
         if self.quantization is not None:
             self.quantization = self.quantization.lower()

--- a/vllm/model_executor/layers/parameters/lazy_compressed.py
+++ b/vllm/model_executor/layers/parameters/lazy_compressed.py
@@ -1,7 +1,6 @@
 import importlib.util
 from typing import Type
 
-import numpy
 import torch
 from torch.utils._pytree import tree_map
 
@@ -119,16 +118,16 @@ class LazyCompressedParameter(torch.Tensor):
                     "does not have 2:4 sparsity, skipping compression")
                 return
 
-        else:
-            sparsity = 1 - (torch.count_nonzero(self.uncompressed_data).item()
-                            / numpy.prod(self.shape))
+        # else:
+        #     sparsity = 1 - (torch.count_nonzero(self.uncompressed_data).item()
+        #                     / numpy.prod(self.shape))
 
-            # Only compress if we have sufficient sparsity (>=40%)
-            if sparsity < 0.4:
-                logger.warning(
-                    f"Called compress() on tensor of shape {self.shape}, but "
-                    f"only has {sparsity:.2}% sparsity, skipping compression")
-                return
+        #     Only compress if we have sufficient sparsity (>=40%)
+        #     if sparsity < 0.4:
+        #         logger.warning(
+        #             f"Called compress() on tensor of shape {self.shape}, but "
+        #             f"only has {sparsity:.2}% sparsity, skipping compression")
+        #         return
 
         if self.uncompressed_data is None:
             raise ValueError(

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -3,12 +3,14 @@ from typing import Type
 from vllm.model_executor.layers.quantization.awq import AWQConfig
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
+from vllm.model_executor.layers.quantization.fp8 import FP8Config
 from vllm.model_executor.layers.quantization.gptq import GPTQConfig
 from vllm.model_executor.layers.quantization.marlin import MarlinConfig
 from vllm.model_executor.layers.quantization.squeezellm import SqueezeLLMConfig
 
 _QUANTIZATION_CONFIG_REGISTRY = {
     "awq": AWQConfig,
+    "fp8": FP8Config,
     "gptq": GPTQConfig,
     "squeezellm": SqueezeLLMConfig,
     "marlin": MarlinConfig,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1,0 +1,152 @@
+from typing import Any, Dict, List, Optional
+
+import torch
+from magic_wand import CompressedStorageFormat
+
+from vllm.model_executor.layers.linear import (LinearMethodBase,
+                                               set_weight_attrs)
+from vllm.model_executor.layers.parameters import LazyCompressedParameter
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig)
+
+
+def fp8_quantize(
+    weight,
+    qdtype: torch.dtype = torch.float8_e4m3fn
+) -> tuple[torch.Tensor, torch.Tensor]:
+    finfo = torch.finfo(qdtype)
+    # Calculate the scale as dtype max divided by absmax
+    scale = finfo.max / weight.abs().max().clamp(min=1e-12)
+    # scale and clamp the tensor to bring it to
+    # the representative range of float8 data type
+    # (as default cast is unsaturated)
+    qweight = (weight * scale).clamp(min=finfo.min, max=finfo.max)
+    # Return both float8 data and the inverse scale (as float),
+    # as both required as inputs to torch._scaled_mm
+    qweight = qweight.to(qdtype)
+    scale = scale.float().reciprocal()
+    return qweight, scale
+
+
+@CompressedStorageFormat._dataclass
+class FP8StorageFormat(CompressedStorageFormat):
+    values: torch.Tensor
+    scale: torch.Tensor
+    dtype: torch.dtype
+
+    @classmethod
+    def compress(cls, uncompressed: torch.Tensor):
+        dtype = uncompressed.dtype
+        compressed, scale = fp8_quantize(uncompressed)
+
+        return cls(values=compressed, scale=scale, dtype=dtype)
+
+    def decompress(self):
+        return self.values.to(self.dtype) * self.scale.to(self.dtype)
+
+
+class FP8Config(QuantizationConfig):
+    """Config class for FP8.
+
+    Reference: https://arxiv.org/abs/2209.05433
+    """
+
+    def __init__(self, qdtype=torch.float8_e4m3fn) -> None:
+        self.qdtype = qdtype
+
+        supported_dtypes = [torch.float8_e4m3fn, torch.float8_e5m2]
+        if self.qdtype not in supported_dtypes:
+            raise ValueError(
+                f"Currently, only {supported_dtypes} are supported types "
+                "for fp8.")
+
+    def __repr__(self) -> str:
+        return (f"FP8Config(qdtype={self.qdtype})")
+
+    def get_name(self) -> str:
+        return "fp8"
+
+    def get_supported_act_dtypes(self) -> List[torch.dtype]:
+        return [torch.half, torch.bfloat16]
+
+    def get_min_capability(self) -> int:
+        # FP8 hardware support is required because
+        # torch._scaled_mm is only supported on CUDA devices with
+        # compute capability >= 9.0 or 8.9, or ROCm MI300+");
+        return 80
+
+    @staticmethod
+    def get_config_filenames() -> List[str]:
+        return []
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "FP8Config":
+        return cls()
+
+    def get_linear_method(self) -> "FP8LinearMethod":
+        return FP8LinearMethod(self)
+
+    def get_scaled_act_names(self) -> List[str]:
+        return ["gelu", "gelu_fast", "gelu_new", "gelu_pytorch_tanh"]
+
+
+class FP8LinearMethod(LinearMethodBase):
+    """Linear method for FP8.
+
+    Args:
+        quant_config: The FP8 quantization config.
+    """
+
+    def __init__(self, quant_config: FP8Config):
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_size_per_partition: int,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        self.dtype = params_dtype
+
+        weight = LazyCompressedParameter(
+            torch.empty(
+                output_size_per_partition,
+                input_size_per_partition,
+                dtype=self.quant_config.qdtype,
+            ),
+            # For create_weights(..), we initialize an empty tensor to
+            # save GPU memory. When the parameter will be loaded from
+            # disk it will be copied into this tensor
+            is_empty=True,
+            storage_format_cls=FP8StorageFormat,
+        )
+        set_weight_attrs(weight, {
+            "input_dim": 1,
+            "output_dim": 0,
+        })
+
+        layer.register_parameter("weight", weight)
+        set_weight_attrs(weight, extra_weight_attrs)
+
+    def apply_weights(self,
+                      layer: torch.nn.Module,
+                      x: torch.Tensor,
+                      bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        w: LazyCompressedParameter = layer.weight
+
+        qx, xscale = fp8_quantize(x)
+
+        output, _ = torch._scaled_mm(
+            qx,
+            w.compressed_data.values,
+            out_dtype=self.dtype,
+            scale_a=xscale,
+            scale_b=w.compressed_data.scale,
+            bias=bias,
+        )
+
+        return output

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -73,7 +73,7 @@ class FP8Config(QuantizationConfig):
         # FP8 hardware support is required because
         # torch._scaled_mm is only supported on CUDA devices with
         # compute capability >= 9.0 or 8.9, or ROCm MI300+");
-        return 80
+        return 89
 
     @staticmethod
     def get_config_filenames() -> List[str]:

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -116,7 +116,7 @@ class FP8LinearMethod(LinearMethodBase):
             torch.empty(
                 output_size_per_partition,
                 input_size_per_partition,
-                dtype=self.quant_config.qdtype,
+                dtype=params_dtype,
             ),
             # For create_weights(..), we initialize an empty tensor to
             # save GPU memory. When the parameter will be loaded from

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -19,7 +19,8 @@ from vllm.config import ModelConfig
 from vllm.logger import init_logger
 # UPSTREAM SYNC: needed for sparsity
 from vllm.model_executor.layers.parameters import LazyCompressedParameter
-from vllm.model_executor.layers.quantization import (QuantizationConfig,
+from vllm.model_executor.layers.quantization import (FP8Config,
+                                                     QuantizationConfig,
                                                      get_quantization_config)
 from vllm.model_executor.layers.quantization.schema import QuantParamSchema
 
@@ -131,6 +132,8 @@ def get_sparse_config(model_config: ModelConfig):
 # TODO(woosuk): Move this to other place.
 def get_quant_config(model_config: ModelConfig) -> QuantizationConfig:
     quant_cls = get_quantization_config(model_config.quantization)
+    if quant_cls == FP8Config:
+        return FP8Config()
     # Read the quantization config from the HF model config, if available.
     hf_quant_config = getattr(model_config.hf_config, "quantization_config",
                               None)


### PR DESCRIPTION
Adds FP8 quantization at runtime for both weights and activations using `torch.float8_e4m3fn`

`torch._scaled_mm` provides an W8A8 linear kernel for FP8, but is only supported on CUDA devices with compute capability >= 9.0 for torch==2.2.1. 
> `RuntimeError: torch._scaled_mm is only supported on devices with compute capability >= 9.0)`

It has been expanded to CUDA 8.9, or ROCm MI300+ on [main](https://github.com/pytorch/pytorch/blob/8ce29f1416f6a3852dc10bfe9326afc6cca4c2f0/aten/src/ATen/native/cuda/Blas.cpp#L825), but won't be on a stable release for a while.

This means for CUDA devices with compute capability < 9.0 (currently everything below Hopper), the weights will be dequantized into higher precision offering no compute savings.

Original precision bfloat16:
```python
from vllm import LLM, SamplingParams

model = LLM("teknium/OpenHermes-2.5-Mistral-7B", enforce_eager=True)
sampling_params = SamplingParams(max_tokens=100, temperature=0)
outputs = model.generate("Once upon a time, ", sampling_params=sampling_params)
print(outputs[0].outputs[0].text)

"""
INFO 04-15 18:29:45 model_runner.py:166] Loading model weights took 13.4976 GB

10 years ago, I was a young, naive, and inexperienced 20-year-old. I had just graduated from college and was about to embark on my first job as a software engineer. I was excited, nervous, and scared all at the same time. I had no idea what to expect, but I was ready to take on the world.
"""
```

Quantized to FP8, specifically float8_e4m3fn:
```python
from vllm import LLM, SamplingParams

model = LLM("teknium/OpenHermes-2.5-Mistral-7B", enforce_eager=True, quantization="fp8")
sampling_params = SamplingParams(max_tokens=100, temperature=0)
outputs = model.generate("Once upon a time, ", sampling_params=sampling_params)
print(outputs[0].outputs[0].text)

"""
INFO 04-15 18:34:48 model_runner.py:166] Loading model weights took 6.9976 GB
WARNING 04-15 18:34:48 fp8.py:20] FP8 hardware support doesn't exist for NVIDIA SM < 9.0. Up-conversion to original dtype will be used.

10 years ago, I was a young, naive, and inexperienced 20-year-old. I had just graduated from college and was about to embark on a new journey in my life. I was about to start my first job as a software engineer.

I was excited and nervous at the same time. I had never worked in a professional environment before, and I didn’t know what to expect. I had heard stories of long hours, difficult
"""