### PR TITLE
WIP: basic correctness test

### DIFF
--- a/neuralmagic/tests/test_basic_correctness.py
+++ b/neuralmagic/tests/test_basic_correctness.py
@@ -1,0 +1,124 @@
+import logging
+
+import openai
+import pytest
+from datasets import load_dataset
+
+from neuralmagic.tools.vllm_server import VllmServer
+from tests.conftest import HfRunnerNM
+from tests.models.compare_utils import check_logprobs_close
+
+
+@pytest.fixture(scope="session")
+def client():
+    client = openai.AsyncOpenAI(
+        base_url="http://localhost:8000/v1",
+        api_key="token-abc123",
+    )
+    yield client
+
+
+@pytest.fixture
+def hf_runner_nm():
+    return HfRunnerNM
+
+
+@pytest.mark.parametrize(
+    "model, max_model_len, sparsity",
+    [
+        ("mistralai/Mistral-7B-Instruct-v0.2", 4096, None),
+        # ("mistralai/Mixtral-8x7B-Instruct-v0.1", 4096, None),
+        # ("neuralmagic/zephyr-7b-beta-marlin", 4096, None),
+        # ("neuralmagic/OpenHermes-2.5-Mistral-7B-pruned50",
+        #  4096, "sparse_w16a16"),
+        # "NousResearch/Llama-2-7b-chat-hf",
+        # "neuralmagic/TinyLlama-1.1B-Chat-v1.0-marlin",
+        # ("neuralmagic/Llama-2-7b-pruned70-retrained-ultrachat",
+        #  4096, "--sparsity sparse_w16a16"),
+        # "HuggingFaceH4/zephyr-7b-gemma-v0.1",
+        # ("Qwen/Qwen1.5-7B-Chat", 4096, None),
+        # ("microsoft/phi-2", 2048, None),
+        # ("neuralmagic/phi-2-super-marlin", 2048, None),
+        # ("neuralmagic/phi-2-pruned50", 2048, "sparse_w16a16"),
+        # ("mistralai/Mixtral-8x7B-Instruct-v0.1", 4096, None),
+        # ("Qwen/Qwen1.5-MoE-A2.7B-Chat", 4096, None),
+        # ("casperhansen/gemma-7b-it-awq", 4096, None),
+        # ("TheBloke/Llama-2-7B-Chat-GPTQ", 4096, None),
+    ])
+@pytest.mark.parametrize("max_tokens", [32])
+@pytest.mark.parametrize("num_logprobs", [3])
+@pytest.mark.asyncio
+async def test_models_on_server(
+    hf_runner_nm,
+    client,
+    model: str,
+    max_model_len: int,
+    sparsity: str,
+    max_tokens: int,
+    num_logprobs: int,
+) -> None:
+
+    ds = load_dataset("nm-testing/qa-chat-prompts", split="train_sft")
+    example_prompts = [m[0]["content"] for m in ds["messages"]]
+    hf_model = hf_runner_nm(model)
+    hf_outputs = hf_model.generate_greedy_logprobs_nm_use_tokens(
+        example_prompts, max_tokens, num_logprobs)
+
+    del hf_model
+
+    logger = logging.Logger("vllm_server")
+    api_server_args = {
+        "--model": model,
+        "--max-model-len": max_model_len,
+        "--disable-log-requests": None,
+    }
+    if sparsity:
+        api_server_args["--sparsity"] = sparsity
+
+    with VllmServer(api_server_args, logger):
+        completion = await client.completions.create(model=model,
+                                                     prompt=example_prompts,
+                                                     max_tokens=max_tokens,
+                                                     temperature=0.0,
+                                                     logprobs=num_logprobs)
+
+    vllm_outputs = []
+    for req_output in completion.choices:
+        output_str = req_output.text
+        output_tokens = req_output.logprobs.tokens
+        output_logprobs = req_output.logprobs.top_logprobs
+        vllm_outputs.append((output_tokens, output_str, output_logprobs))
+
+    # loop through the prompts
+    check_logprobs_close(
+        outputs_0_lst=hf_outputs,
+        outputs_1_lst=vllm_outputs,
+        name_0="hf_model",
+        name_1="vllm_model",
+    )
+
+    # now repeat using two gpus
+    # specifically doing it here, rather than as a pytest param,
+    # to avoid repeating the huggingface inference and data collection
+    api_server_args["--tensor-parallel-size"] = 2
+    with VllmServer(api_server_args, logger):
+        completion = await client.completions.create(model=model,
+                                                     prompt=example_prompts,
+                                                     max_tokens=max_tokens,
+                                                     temperature=0.0,
+                                                     logprobs=num_logprobs)
+
+    vllm_outputs = []
+    for req_output in completion.choices:
+        output_str = req_output.text
+        output_tokens = req_output.logprobs.tokens
+        output_logprobs = req_output.logprobs.top_logprobs
+        vllm_outputs.append((output_tokens, output_str, output_logprobs))
+
+    # loop through the prompts
+    check_logprobs_close(
+        outputs_0_lst=hf_outputs,
+        outputs_1_lst=vllm_outputs,
+        name_0="hf_model",
+        name_1="vllm_model",
+    )

--- a/neuralmagic/tools/vllm_server.py
+++ b/neuralmagic/tools/vllm_server.py
@@ -1,0 +1,141 @@
+import logging
+import shlex
+import sys
+import time
+from subprocess import STDOUT, Popen
+from tempfile import TemporaryFile
+from typing import Dict, List
+from urllib.parse import urljoin
+
+import requests
+
+
+def log_banner(logger: logging.Logger,
+               label: str,
+               body: str,
+               level: int = logging.INFO):
+    """
+    Log a message in the "banner"-style format.
+    :param logger: Instance of "logging.Logger" to use
+    :param label: Label for the top of the banner
+    :param body: Body content inside the banner
+    :param level: Logging level to use (default: INFO)
+    """
+
+    banner = f"==== {label} ====\n{body}\n===="
+    logger.log(level, "\n%s", banner)
+
+
+class BaseVllmServerError(Exception):
+    """Base exception class for VllmServer errors."""
+
+
+class VllmServerDiedError(BaseVllmServerError):
+    """Error indicating that the vLLM server died unexpectedly."""
+
+
+class VllmServerTimeoutError(BaseVllmServerError):
+    """Error indicating that the vLLM server took too long to become ready."""
+
+
+class VllmServer:
+    """Context manager for the lifecycle of a vLLM server"""
+
+    def __init__(self, args: Dict[str, str], logger: logging.Logger) -> None:
+        """Initialize a vLLM server
+        :param args: dict of commands to pass to the server shell command
+        :param logger: logging.Logger instance to use for logging
+        """
+        self._args = self._args_to_list(args)
+        self._cmd = [
+            sys.executable,
+            "-m",
+            "vllm.entrypoints.openai.api_server",
+            *self._args,
+        ]
+        # TODO: Is there an alternative/short-flag to also check, e.g. "-p"?
+        self._port = args.get("--port", "8000")
+        self._logger = logger
+        pass
+
+    def __enter__(self):
+        """Executes the server process and waits for it to become ready."""
+        log_banner(self._logger, "server startup command",
+                   shlex.join(self._cmd), logging.DEBUG)
+        command = self._cmd
+        self._output_file = TemporaryFile()
+        self._process = Popen(command,
+                              stdout=self._output_file.fileno(),
+                              stderr=STDOUT)
+        self._wait_for_ready()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        """Stops the server if it's still running and captures/logs its
+        output"""
+        if hasattr(self, "_process") and self._process.poll() is None:
+            self._process.terminate()
+
+        # capture and log server output
+        self._output_file.seek(0)
+        self.output = self._output_file.read().decode(errors="backslash")
+        self._output_file.close()
+        log_banner(self._logger, "server output", self.output, logging.DEBUG)
+
+    def _args_to_list(self, args: Dict[str, str]) -> List[str]:
+        """Convert a dict mapping of CLI args to a list
+        :param args: `dict` containing CLI flags and their values (all strings)
+        :return: flattened list to pass to a CLI
+        """
+
+        arg_list: List[str] = []
+        for flag, value in args.items():
+            # some error-checking safety as resulting list must be all strings
+            if not isinstance(flag, str):
+                error = f"all flags must be strings, got {type(flag)} ({flag})"
+                raise ValueError(error)
+            if not isinstance(value, str):
+                error = (f"all values must be strings, got {type(value)} "
+                         f"({value})")
+                raise ValueError(error)
+
+            arg_list.append(flag)
+            if value != "":
+                arg_list.append(value)
+
+        return arg_list
+
+    def _is_ready(self) -> bool:
+        """Determine if server is ready based on response from `/health`
+        endpoint
+        :raises VllmServerDiedError: raised if the server process is no longer
+            running
+        :return: boolean state of the server's readiness
+        """
+        health_url = urljoin(f"http://localhost:{self._port}", "/health")
+        try:
+            rsp = requests.get(health_url, timeout=5)
+            rsp.raise_for_status()
+            return rsp.status_code == requests.status_codes.codes.ok
+        except Exception as e:
+            if self._process.poll() is not None:
+                error = "server process not running when performing ready-check"
+                raise VllmServerDiedError(error) from e
+            return False
+
+    def _wait_for_ready(self, limit: int = 600):
+        """Wait for the server to become ready up to `limit` seconds
+        (default: 600)
+        :param limit: time in seconds to wait for the server to become ready
+            (default: 600)
+        :raises VllmServerTimeoutError: raised if the server does not become
+            ready in the specified time limit
+        """
+        start = time.time()
+        while True:
+            if self._is_ready():
+                return
+            time.sleep(0.25)
+            if time.time() - start > limit:
+                error = f"did not become ready within {limit} seconds"
+                raise VllmServerTimeoutError(error)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ types-requests
 types-setuptools
 
 # testing
+datasets
 pytest
 pytest-forked
 pytest-asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -346,6 +346,74 @@ class HfRunnerNM(HfRunner):
         return [(output_ids, output_str, output_logprobs)
                 for output_ids, output_str, output_logprobs in outputs]
 
+    def generate_greedy_logprobs_nm_use_tokens(
+        self,
+        prompts: List[str],
+        max_tokens: int,
+        num_logprobs: int,
+    ) -> List[Tuple[List[int], str]]:
+        all_logprobs = []
+        all_output_ids = []
+        all_output_strs = []
+
+        for prompt in prompts:
+            input_ids = self.tokenizer(prompt, return_tensors="pt").input_ids
+            output = self.model.generate(
+                input_ids.cuda(),
+                use_cache=True,
+                do_sample=False,
+                max_new_tokens=max_tokens,
+                output_hidden_states=True,
+                return_dict_in_generate=True,
+            )
+
+            seq_logprobs = []
+            for _, hidden_states in enumerate(output.hidden_states):
+                last_hidden_states = hidden_states[-1][0]
+                logits = torch.matmul(
+                    last_hidden_states,
+                    self.model.get_output_embeddings().weight.t(),
+                )
+                if self.model.get_output_embeddings().bias is not None:
+                    logits += self.model.get_output_embeddings(
+                    ).bias.unsqueeze(0)
+                logprobs = torch.nn.functional.log_softmax(logits,
+                                                           dim=-1,
+                                                           dtype=torch.float32)
+                seq_logprobs.append(logprobs)
+
+            # convert to dict
+            seq_logprobs_lst = []
+            for tok_idx, tok_logprobs in enumerate(seq_logprobs):
+                # drop prompt logprobs
+                if tok_idx == 0:
+                    tok_logprobs = tok_logprobs[-1, :].reshape(1, -1)
+                topk = tok_logprobs.topk(num_logprobs)
+
+                tok_logprobs_dct = {}
+                for token_id, logprob in zip(topk.indices[0], topk.values[0]):
+                    tok_logprobs_dct[self.tokenizer.decode(
+                        token_id.item())] = logprob.item()
+
+                seq_logprobs_lst.append(tok_logprobs_dct)
+
+            all_logprobs.append(seq_logprobs_lst)
+            seq_ids = output.sequences[0]
+            output_len = seq_ids.shape[0] - input_ids.shape[1]
+            output_ids = seq_ids[-output_len:]
+            all_output_ids.append([
+                self.tokenizer.decode(id, clean_up_tokenization_spaces=False)
+                for id in output_ids
+            ])
+            all_output_strs.append("".join([
+                self.tokenizer.decode(id, clean_up_tokenization_spaces=False)
+                for id in output_ids
+            ]))
+
+        outputs = zip(all_output_ids, all_output_strs, all_logprobs)
+        return [(output_ids, output_str, output_logprobs)
+                for output_ids, output_str, output_logprobs in outputs]
+
 
 @pytest.fixture
 def hf_runner_nm():

--- a/tests/models/compare_utils.py
+++ b/tests/models/compare_utils.py
@@ -12,20 +12,22 @@ def check_logprobs_close(outputs_0_lst, outputs_1_lst, name_0, name_1):
         output_ids_1, output_str_1, logprobs_1 = outputs_1
 
         # Loop through generated tokens.
-        for idx, (output_id_0,
-                  output_id_1) in enumerate(zip(output_ids_0, output_ids_1)):
+        for idx, (output_token_0,
+                  output_token_1) in enumerate(zip(output_ids_0,
+                                                   output_ids_1)):
 
             # If generated tokens don't match, then
-            if output_id_0 != output_id_1:
+            if output_token_0 != output_token_1:
                 # Each predicted token must be in top N logprobs of the other
-                assert output_id_0 in logprobs_1[idx], (
+                assert output_token_0 in [
+                    s.strip() for s in logprobs_1[idx]
+                ], (f"Test{prompt_idx}:"
+                    f"\n{name_0}:\t{output_token_0!r}"
+                    f"\n{name_1}:\t{output_token_1!r}")
+                assert output_token_1.strip() in logprobs_0[idx], (
                     f"Test{prompt_idx}:"
-                    f"\n{name_0}:\t{output_str_0!r}"
-                    f"\n{name_1}:\t{output_str_1!r}")
-                assert output_id_1 in logprobs_0[idx], (
-                    f"Test{prompt_idx}:"
-                    f"\n{name_0}:\t{output_str_0!r}"
-                    f"\n{name_1}:\t{output_str_1!r}")
+                    f"\n{name_0}:\t{output_token_0!r}"
+                    f"\n{name_1}:\t{output_token_1!r}")
 
                 # Break out since sequences will now diverge.
                 break


### PR DESCRIPTION
Introducing an end-to-end test case that verifies basic correctness of the vllm engine by comparing the tokens output by the vllm OpenAI server with tokens generated by the HuggingFace model created by `AutoModelForCausalLM.from_pretrained()`.
This Work In Progress PR is intended to verify the approach used to reconcile the different logprobs output generated by the server (keyed by tokens) vs that generated by the HF model (keyed by token id). It uses duplicate code in the `tests.conftest.HfRunnerNM.generate_greedy_logprobs_nm_use_tokens()` method, replacing a token id with the actual token. As long as this approach is approved, I'll come up with some code refactoring to reduce this, and other code duplication used in other fixtures in `conftest.py`.
The use of the new `VllmServer` class is also an open question as we are still determining the actual infrastructure that will be used to execute this test. [credit to Domenic Barbuzzi for the VllmServer code]
