### PR TITLE
GCP related build workflow updates

### DIFF
--- a/.github/actions/nm-build-vllm/action.yml
+++ b/.github/actions/nm-build-vllm/action.yml
@@ -32,7 +32,7 @@ runs:
       VENV="${{ inputs.venv }}-${COMMIT:0:7}"
       source $(pyenv root)/versions/${{ inputs.python }}/envs/${VENV}/bin/activate
       # TODO: adjust when we need a proper release. use nightly now.
-      pip3 install --index-url http://${{ inputs.pypi }}:8080/ --trusted-host ${{ inputs.pypi }} nm-magic-wand-nightly
+      pip3 install nm-magic-wand-nightly
       pip3 install -r requirements-cuda.txt -r requirements-build.txt
       # build
       SUCCESS=0

--- a/.github/actions/nm-lint-python/action.yml
+++ b/.github/actions/nm-lint-python/action.yml
@@ -1,5 +1,5 @@
 name: lint python
-description: "runs 'ruff' and reports errors"
+description: "(DEPRECATED) runs 'ruff' and reports errors"
 outputs:
   status:
     description: "return code from 'ruff'"

--- a/.github/actions/nm-set-env/action.yml
+++ b/.github/actions/nm-set-env/action.yml
@@ -25,7 +25,7 @@ runs:
       echo "PYENV_ROOT=/usr/local/apps/pyenv" >> $GITHUB_ENV
       echo "XDG_CONFIG_HOME=/usr/local/apps" >> $GITHUB_ENV
       WHOAMI=$(whoami)
-      echo "PATH=/usr/local/apps/pyenv/plugins/pyenv-virtualenv/shims:/usr/local/apps/pyenv/shims:/usr/local/apps/pyenv/bin:/usr/local/apps/nvm/versions/node/v16.20.2/bin:/usr/local/cuda-12.1/bin:/usr/local/cuda-12.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/${WHOAMI}/.local/bin:" >> $GITHUB_ENV
+      echo "PATH=/usr/local/apps/pyenv/plugins/pyenv-virtualenv/shims:/usr/local/apps/pyenv/shims:/usr/local/apps/pyenv/bin:/usr/local/apps/nvm/versions/node/v19.9.0/bin:/usr/local/apps/nvm/versions/node/v16.20.2/bin:/usr/local/cuda-12.1/bin:/usr/local/cuda-12.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/${WHOAMI}/.local/bin:" >> $GITHUB_ENV
       echo "LD_LIBRARY_PATH=/usr/local/cuda-12.1/lib64::/usr/local/cuda-12.1/lib64:" >> $GITHUB_ENV
       echo "PROJECT_ID=12" >> $GITHUB_ENV
     env:

--- a/.github/actions/nm-set-python/action.yml
+++ b/.github/actions/nm-set-python/action.yml
@@ -25,6 +25,7 @@ runs:
         pyenv virtualenv ${VENV} || true
         source $(pyenv root)/versions/${{ inputs.python }}/envs/${VENV}/bin/activate
         pyenv versions
+        pip3 install -r requirements-dev.txt
         VERSION=$(python --version)
         echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/actions/nm-set-python/action.yml
+++ b/.github/actions/nm-set-python/action.yml
@@ -17,15 +17,11 @@ runs:
     - id: set_python
       run: |
         command -v pyenv
-        pyenv root
-        pyenv versions
         pyenv local ${{ inputs.python }}
         COMMIT=${{ github.sha }}
         VENV="${{ inputs.venv }}-${COMMIT:0:7}"
         pyenv virtualenv ${VENV} || true
         source $(pyenv root)/versions/${{ inputs.python }}/envs/${VENV}/bin/activate
-        pyenv versions
-        pip3 install -r requirements-dev.txt
         VERSION=$(python --version)
         echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/actions/nm-set-python/action.yml
+++ b/.github/actions/nm-set-python/action.yml
@@ -22,7 +22,7 @@ runs:
         pyenv local ${{ inputs.python }}
         COMMIT=${{ github.sha }}
         VENV="${{ inputs.venv }}-${COMMIT:0:7}"
-        pyenv virtualenv ${VENV}
+        pyenv virtualenv ${VENV} || true
         source $(pyenv root)/versions/${{ inputs.python }}/envs/${VENV}/bin/activate
         pyenv versions
         VERSION=$(python --version)

--- a/.github/actions/nm-summary-build/action.yml
+++ b/.github/actions/nm-summary-build/action.yml
@@ -13,9 +13,6 @@ inputs:
   python:
     description: 'python version info'
     required: true
-  lint_status:
-    description: 'status from python lint step'
-    required: true
   build_status:
     description: 'status from build step'
     required: true
@@ -26,8 +23,6 @@ runs:
   using: composite
   steps:
   - run: |
-      LINT_STATUS=${{ inputs.lint_status }}
-      LINT_EMOJI=$(./.github/scripts/step-status ${LINT_STATUS})
       BUILD_STATUS=${{ inputs.build_status }}
       BUILD_EMOJI=$(./.github/scripts/step-status ${BUILD_STATUS})
       WHL_STATUS=${{ inputs.whl_status }}
@@ -42,7 +37,6 @@ runs:
       echo "| gitref: | '${{ inputs.gitref }}' |" >> $GITHUB_STEP_SUMMARY
       echo "| branch name: | '${{ github.ref_name }}' |" >> $GITHUB_STEP_SUMMARY
       echo "| python: | ${{ inputs.python }} |" >> $GITHUB_STEP_SUMMARY
-      echo "| lint: | ${LINT_EMOJI} |" >> $GITHUB_STEP_SUMMARY
       echo "| build: | ${BUILD_EMOJI} |" >> $GITHUB_STEP_SUMMARY
       echo "| whl: | ${WHL_EMOJI} |" >> $GITHUB_STEP_SUMMARY
     shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,14 +97,14 @@ jobs:
                 python: ${{ inputs.python }}
                 venv: ${{ env.VENV_BASE }}
 
-            - name: create testmo run
-              id: create_testmo_run
-              uses: ./.github/actions/nm-testmo-run-create/
-              if: success() || failure()
-              with:
-                testmo_url: https://neuralmagic.testmo.net
-                testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}
-                source: 'build-test'
+            # - name: create testmo run
+            #   id: create_testmo_run
+            #   uses: ./.github/actions/nm-testmo-run-create/
+            #   if: success() || failure()
+            #   with:
+            #     testmo_url: https://neuralmagic.testmo.net
+            #     testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}
+            #     source: 'build-test'
 
             - name: python lint
               id: lint
@@ -161,10 +161,10 @@ jobs:
                 if [ -z "${BUILD_STATUS}" ] || [ "${BUILD_STATUS}" -ne "0" ]; then exit 1; fi
                 if [ -z "${WHL_STATUS}" ] || [ "${WHL_STATUS}" -ne "0" ]; then exit 1; fi
 
-            - name: complete testmo run
-              uses: ./.github/actions/nm-testmo-run-complete/
-              if: success() || failure()
-              with:
-                testmo_url: https://neuralmagic.testmo.net
-                testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}
-                testmo_run_id: ${{ steps.create_testmo_run.outputs.id }}
+            # - name: complete testmo run
+            #   uses: ./.github/actions/nm-testmo-run-complete/
+            #   if: success() || failure()
+            #   with:
+            #     testmo_url: https://neuralmagic.testmo.net
+            #     testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}
+            #     testmo_run_id: ${{ steps.create_testmo_run.outputs.id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,9 +106,9 @@ jobs:
             #     testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}
             #     source: 'build-test'
 
-            - name: python lint
-              id: lint
-              uses: ./.github/actions/nm-lint-python/
+            # - name: python lint
+            #   id: lint
+            #   uses: ./.github/actions/nm-lint-python/
 
             - name: build
               id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,8 @@ jobs:
             #     testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}
             #     source: 'build-test'
 
+            # TODO: DELETE
+            # stop replicating ruff check ... other workflows do this already
             # - name: python lint
             #   id: lint
             #   uses: ./.github/actions/nm-lint-python/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,10 @@ jobs:
 
         steps:
 
+            - name: okay
+              run: |
+                whoami
+
             - name: checkout
               id: checkout
               uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,9 @@ on:
         type: string
         required: true
 
+env:
+    VENV_BASE: "BUILD"
+
 jobs:
 
     BUILD:
@@ -88,13 +91,7 @@ jobs:
               uses: ./.github/actions/nm-set-python/
               with:
                 python: ${{ inputs.python }}
-                venv: TEST
-
-            - name: hf cache
-              id: hf_cache
-              uses: ./.github/actions/nm-hf-cache/
-              with:
-                fs_cache: ${{ secrets.HF_FS_CACHE }}
+                venv: ${{ env.VENV_BASE }}
 
             - name: create testmo run
               id: create_testmo_run
@@ -114,7 +111,7 @@ jobs:
               uses: ./.github/actions/nm-build-vllm/
               with:
                 python: ${{ inputs.python }}
-                venv: TEST
+                venv: ${{ env.VENV_BASE }}
                 pypi: ${{ secrets.NM_PRIVATE_PYPI_LOCATION }}
 
             - name: upload whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,10 +70,6 @@ jobs:
 
         steps:
 
-            - name: okay
-              run: |
-                whoami
-
             - name: checkout
               id: checkout
               uses: actions/checkout@v4
@@ -97,20 +93,14 @@ jobs:
                 python: ${{ inputs.python }}
                 venv: ${{ env.VENV_BASE }}
 
-            # - name: create testmo run
-            #   id: create_testmo_run
-            #   uses: ./.github/actions/nm-testmo-run-create/
-            #   if: success() || failure()
-            #   with:
-            #     testmo_url: https://neuralmagic.testmo.net
-            #     testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}
-            #     source: 'build-test'
-
-            # TODO: DELETE
-            # stop replicating ruff check ... other workflows do this already
-            # - name: python lint
-            #   id: lint
-            #   uses: ./.github/actions/nm-lint-python/
+            - name: create testmo run
+              id: create_testmo_run
+              uses: ./.github/actions/nm-testmo-run-create/
+              if: success() || failure()
+              with:
+                testmo_url: https://neuralmagic.testmo.net
+                testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}
+                source: 'build-test'
 
             - name: build
               id: build
@@ -144,7 +134,6 @@ jobs:
                 gitref: ${{ inputs.gitref }}
                 testmo_run_url: https://neuralmagic.testmo.net/automation/runs/view/${{ steps.create_testmo_run.outputs.id }}
                 python: ${{ steps.set_python.outputs.version }}
-                lint_status: ${{ steps.lint.outputs.status }}
                 build_status: ${{ steps.build.outputs.build_status }}
                 whl_status: ${{ steps.build.outputs.whl_status }}
 
@@ -152,21 +141,18 @@ jobs:
               id: run_status
               if: success() || failure()
               env:
-                LINT_STATUS: ${{ steps.lint.outputs.status }}
                 BUILD_STATUS: ${{ steps.build.outputs.build_status }}
                 WHL_STATUS: ${{ steps.build.outputs.whl_status }}
               run: |
-                echo "lint status: ${LINT_STATUS}"
                 echo "build status: ${BUILD_STATUS}"
                 echo "build status: ${WHL_STATUS}"
-                if [ -z "${LINT_STATUS}" ] || [ "${LINT_STATUS}" -ne "0" ]; then exit 1; fi
                 if [ -z "${BUILD_STATUS}" ] || [ "${BUILD_STATUS}" -ne "0" ]; then exit 1; fi
                 if [ -z "${WHL_STATUS}" ] || [ "${WHL_STATUS}" -ne "0" ]; then exit 1; fi
 
-            # - name: complete testmo run
-            #   uses: ./.github/actions/nm-testmo-run-complete/
-            #   if: success() || failure()
-            #   with:
-            #     testmo_url: https://neuralmagic.testmo.net
-            #     testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}
-            #     testmo_run_id: ${{ steps.create_testmo_run.outputs.id }}
+            - name: complete testmo run
+              uses: ./.github/actions/nm-testmo-run-complete/
+              if: success() || failure()
+              with:
+                testmo_url: https://neuralmagic.testmo.net
+                testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}
+                testmo_run_id: ${{ steps.create_testmo_run.outputs.id }}


### PR DESCRIPTION
SUMMARY:
* overall this removes dependencies for being on the VPC/VPN from the build stage, e.g. installing "magic wand nightly" from private pypi
* removes redundant python lint check step, deprecates lint action, and removes lint info from summary
* makes python VENV creation more robust when the VENV already exists

TEST PLAN:
runs on remote push using our AWS runners. this has been green. i've also manually ran the build workflow on GCP static runners.
