### PR TITLE
switch to GCP based build VM

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -69,7 +69,7 @@ jobs:
     BUILD:
         uses: ./.github/workflows/build.yml
         with:
-            build_label: aws-avx512-192G-4-T4-64G
+            build_label: ${{ inputs.build_label }}
             timeout: ${{ inputs.timeout }}
             gitref: ${{ inputs.gitref }}
             Gi_per_thread: ${{ inputs.Gi_per_thread }}

--- a/.github/workflows/remote-push.yml
+++ b/.github/workflows/remote-push.yml
@@ -18,11 +18,11 @@ jobs:
                 python: [3.10.12]
         uses: ./.github/workflows/build-test.yml
         with:
-            build_label: aws-avx512-192G-4-T4-64G
-            timeout: 360
+            build_label: gcp-build-static
+            timeout: 240
             gitref: '${{ github.ref }}'
-            Gi_per_thread: 4
-            nvcc_threads: 8
+            Gi_per_thread: 1
+            nvcc_threads: 4
             python: ${{ matrix.python }}
             test_skip_list: neuralmagic/tests/skip-for-remote-push.txt
         secrets: inherit
@@ -35,8 +35,8 @@ jobs:
             benchmark_config_list_file:  ./.github/data/nm_benchmark_remote_push_configs_list.txt
             timeout: 180
             gitref: '${{ github.ref }}'
-            Gi_per_thread: 12
-            nvcc_threads: 1
-            python: "3.10.12"
+            Gi_per_thread: 1
+            nvcc_threads: 4
+            python: 3.10.12
             push_benchmark_results_to_gh_pages: "false"
         secrets: inherit


### PR DESCRIPTION
SUMMARY:
* switch over to GCP VM's for building stage of "remote push"

NOTE: this is just the start. i'll redo the benchmarking and nightly workflows in an upcoming PR.

TEST PLAN:
runs on remote push
