### PR TITLE
cleanup venv

### DIFF
--- a/.github/actions/nm-build-vllm/action.yml
+++ b/.github/actions/nm-build-vllm/action.yml
@@ -44,7 +44,6 @@ runs:
       # whl
       SUCCESS=0
       pip3 wheel --no-deps -w dist . || SUCCESS=$?
-      pyenv uninstall --force ${{ inputs.python}}/envs/${VENV}
       echo "whl_status=${SUCCESS}" >> "$GITHUB_OUTPUT"
       BASE=$(./.github/scripts/convert-version ${{ inputs.python }})
       ls -alh dist
@@ -58,6 +57,7 @@ runs:
       fi
       # sdist
       python3 setup.py sdist || SUCCESS=$?
+      pyenv uninstall --force ${{ inputs.python}}/envs/${VENV}
       ls -alh dist
       TAR_FILEPATH=$(find dist -type f -iname "*.tar.gz")
       echo "${TAR_FILEPATH}"

--- a/.github/actions/nm-build-vllm/action.yml
+++ b/.github/actions/nm-build-vllm/action.yml
@@ -44,6 +44,7 @@ runs:
       # whl
       SUCCESS=0
       pip3 wheel --no-deps -w dist . || SUCCESS=$?
+      pyenv uninstall --force ${{ inputs.python}}/envs/${VENV}
       echo "whl_status=${SUCCESS}" >> "$GITHUB_OUTPUT"
       BASE=$(./.github/scripts/convert-version ${{ inputs.python }})
       ls -alh dist


### PR DESCRIPTION
SUMMARY:
* cleanup venv after build is complete

TEST PLAN:
runs on remote push

checked the VM and it did in fact delete the venv for run corresponding to `COMMIT=dc4ebd1bf17b41333a02854b5e6fa6f8e66f4595`

```
ubuntu@builder2-static:~$ pyenv versions
* system (set by /usr/local/apps/pyenv/version)
  3.8.17
  3.9.17
  3.10.12
  3.10.12/envs/BUILD-fd05293
  3.11.4
  BUILD-fd05293 --> /usr/local/apps/pyenv/versions/3.10.12/envs/BUILD-fd05293
```
