### PR TITLE
switch to k8s runners

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ on:
       build_label:
         description: "requested runner label (specifies instance)"
         type: string
-        default: "gcp-build-static"
+        default: gcp-k8s-build
       build_timeout:
         description: "time limit for build in minutes "
         type: string


### PR DESCRIPTION
SUMMARY:
* switch build phase to GCP k8s cluster

TEST PLAN:
runs on remote push
