### PR TITLE
version check patch

### DIFF
--- a/.github/actions/nm-install-test-whl/action.yml
+++ b/.github/actions/nm-install-test-whl/action.yml
@@ -51,8 +51,9 @@ runs:
         echo "whl=${WHL_BASENAME}" >> "$GITHUB_OUTPUT"
         pip3 install ${WHL}[sparse]
         # report magic_wand version
-        MAGIC_WAND=$(pip3 show nm-magic-wand-nightly || "" | grep "Version" | cut -d' ' -f2) || echo "nightly not installed"
+        MAGIC_WAND=$(pip3 show nm-magic-wand-nightly | grep "Version" | cut -d' ' -f2) || echo "nightly not installed"
         if [ -z "${MAGIC_WAND}" ]; then
+          # if neither magic-wand nor magic-wand-nightly is installed stop here with error
           MAGIC_WAND=$(pip3 show nm-magic-wand | grep "Version" | cut -d' ' -f2)
         fi
         echo "magic_wand=${MAGIC_WAND}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/nm-install-test-whl/action.yml
+++ b/.github/actions/nm-install-test-whl/action.yml
@@ -51,7 +51,7 @@ runs:
         echo "whl=${WHL_BASENAME}" >> "$GITHUB_OUTPUT"
         pip3 install ${WHL}[sparse]
         # report magic_wand version
-        MAGIC_WAND=$(pip3 show nm-magic-wand-nightly | grep "Version" | cut -d' ' -f2)
+        MAGIC_WAND=$(pip3 show nm-magic-wand-nightly || "" | grep "Version" | cut -d' ' -f2) || echo "nightly not installed"
         if [ -z "${MAGIC_WAND}" ]; then
           MAGIC_WAND=$(pip3 show nm-magic-wand | grep "Version" | cut -d' ' -f2)
         fi


### PR DESCRIPTION
SUMMARY:
* make `magic-wand` version check robust

TEST PLAN:
runs on remote push. will be manually triggering NIGHTLY and RELEASE relative to this branch.

```bash
andy@waldorf:~$ cat test.sh 
#!/bin/bash

set -euo pipefail

MAGIC_WAND=$(pip3 show nm-magic-wand-nightly | grep "Version" | cut -d' ' -f2) || echo "nightly not installed" 
if [ -z "$MAGIC_WAND" ]; then
    MAGIC_WAND=$(pip3 show nm-magic-wand | grep "Version" | cut -d' ' -f2)
fi

echo ${MAGIC_WAND}

andy@waldorf:~$ ./test.sh 
WARNING: Package(s) not found: nm-magic-wand-nightly
nightly not installed
0.2.2
andy@waldorf:~$ echo $?
0
```

when "nightly" is installed ... 

```bash
andy@waldorf:~$ ./test.sh 
0.2.2.20240520
```

