### PR TITLE
Address py38/39 incompatibilities

### DIFF
--- a/neuralmagic/benchmarks/run_benchmark_serving.py
+++ b/neuralmagic/benchmarks/run_benchmark_serving.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 import time
 from pathlib import Path
-from typing import NamedTuple, Optional
+from typing import List, NamedTuple, Optional
 
 import requests
 
@@ -62,7 +62,7 @@ def run_benchmark_serving_script(config: NamedTuple,
                                  ) -> None:
     assert config.script_name == 'benchmark_serving'
 
-    def run_bench(server_cmd: str, bench_cmd: list[str], model: str) -> None:
+    def run_bench(server_cmd: str, bench_cmd: List[str], model: str) -> None:
         try:
             # start server
             server_process = subprocess.Popen("exec " + server_cmd, shell=True)

--- a/tests/async_engine/test_merge_async_iterators.py
+++ b/tests/async_engine/test_merge_async_iterators.py
@@ -1,4 +1,6 @@
 import asyncio
+# UPSTREAM SYNC
+import sys
 from typing import AsyncIterator, Tuple
 
 import pytest
@@ -6,6 +8,9 @@ import pytest
 from vllm.utils import merge_async_iterators
 
 
+# UPSTREAM SYNC
+@pytest.mark.skipif(sys.version_info < (3, 10),
+                    reason="`anext` requires Python 3.10")
 @pytest.mark.asyncio
 async def test_merge_async_iterators():
 

--- a/tests/engine/test_multiproc_workers.py
+++ b/tests/engine/test_multiproc_workers.py
@@ -99,13 +99,12 @@ def test_local_workers() -> None:
         assert isinstance(e, ChildProcessError)
 
 
+# UPSTREAM SYNC
+@pytest.mark.skipif(sys.version_info < (3, 10),
+                    reason="This test is inexplicably failing in CI "
+                    "on Python < 3.10")
 def test_local_workers_clean_shutdown() -> None:
     """Test clean shutdown"""
-
-    # UPSTREAM SYNC
-    pytest.mark.skipif(sys.version_info < (3, 10),
-                       reason="This test is inexplicably failing in CI "
-                       "on Python < 3.10")
 
     workers, worker_monitor = _start_workers()
 

--- a/tests/engine/test_multiproc_workers.py
+++ b/tests/engine/test_multiproc_workers.py
@@ -1,6 +1,4 @@
 import asyncio
-# UPSTREAM SYNC
-import sys
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from time import sleep
@@ -99,10 +97,6 @@ def test_local_workers() -> None:
         assert isinstance(e, ChildProcessError)
 
 
-# UPSTREAM SYNC
-@pytest.mark.skipif(sys.version_info < (3, 10),
-                    reason="This test is inexplicably failing in CI "
-                    "on Python < 3.10")
 def test_local_workers_clean_shutdown() -> None:
     """Test clean shutdown"""
 


### PR DESCRIPTION
**SUMMARY**

Handle a few different Python 3.8/3.9 compatibility issues:
* Fix the Python 3.8 compatibility in one of our benchmarking scripts.
* Fix skip for `test_local_workers_clean_shutdown` (previous skip attempt misused `pytest.mark.skipif`)
* Skip `test_merge_async_iterators` (uses Python builtin `anext` which was added in 3.10)
