### PR TITLE
bump up version and gate magic-wand version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -411,6 +411,14 @@ if _is_cuda():
 if not _is_neuron():
     ext_modules.append(CMakeExtension(name="vllm._C"))
 
+# UPSTREAM SYNC: needed for sparsity
+_sparsity_deps = ["nm-magic-wand-nightly"]
+nm_release_type = os.getenv(NM_RELEASE_TYPE)
+if nm_release_type == 'RELEASE':
+    # gate magic-wand version in nm-vllm for release; for nightly, we always install the latest
+    magic_wand_version_dep = "0.2.2"
+    _sparsity_deps = [f"nm-magic-wand~={magic_wand_version_dep}"]
+
 package_data = {
     "vllm": ["py.typed", "model_executor/layers/fused_moe/configs/*.json"]
 }
@@ -452,13 +460,6 @@ setup(
     python_requires=">=3.8",
     install_requires=get_requirements(),
     ext_modules=ext_modules,
-    # UPSTREAM SYNC: needed for sparsity
-    _sparsity_deps = ["nm-magic-wand-nightly"]
-    nm_release_type = os.getenv(NM_RELEASE_TYPE)
-    if nm_release_type == 'RELEASE':
-        # gate magic-wand version in nm-vllm for release; for nightly, we always install the latest
-        magic_wand_version_dep = "0.2.2"
-        _sparsity_deps = [f"nm-magic-wand~={magic_wand_version_dep}"]
     extras_require={
         "tensorizer": ["tensorizer==2.9.0"],
         # UPSTREAM SYNC: required for sparsity

--- a/setup.py
+++ b/setup.py
@@ -453,7 +453,7 @@ setup(
     install_requires=get_requirements(),
     ext_modules=ext_modules,
     # UPSTREAM SYNC: needed for sparsity
-    _sparsity_deps = [f"nm-magic-wand-nightly"]
+    _sparsity_deps = ["nm-magic-wand-nightly"]
     nm_release_type = os.getenv(NM_RELEASE_TYPE)
     if nm_release_type == 'RELEASE':
         # gate magic-wand version in nm-vllm for release; for nightly, we always install the latest

--- a/setup.py
+++ b/setup.py
@@ -411,12 +411,6 @@ if _is_cuda():
 if not _is_neuron():
     ext_modules.append(CMakeExtension(name="vllm._C"))
 
-# UPSTREAM SYNC: needed for sparsity
-_sparsity_deps = ["nm-magic-wand-nightly"]
-nm_release_type = os.getenv(NM_RELEASE_TYPE)
-if nm_release_type == 'RELEASE':
-    _sparsity_deps = ["nm-magic-wand"]
-
 package_data = {
     "vllm": ["py.typed", "model_executor/layers/fused_moe/configs/*.json"]
 }
@@ -458,6 +452,11 @@ setup(
     python_requires=">=3.8",
     install_requires=get_requirements(),
     ext_modules=ext_modules,
+    # UPSTREAM SYNC: needed for sparsity
+    _sparsity_deps = [f"nm-magic-wand-nightly~={version}"]
+    nm_release_type = os.getenv(NM_RELEASE_TYPE)
+    if nm_release_type == 'RELEASE':
+        _sparsity_deps = [f"nm-magic-wand~={version}"]
     extras_require={
         "tensorizer": ["tensorizer==2.9.0"],
         # UPSTREAM SYNC: required for sparsity

--- a/setup.py
+++ b/setup.py
@@ -453,10 +453,12 @@ setup(
     install_requires=get_requirements(),
     ext_modules=ext_modules,
     # UPSTREAM SYNC: needed for sparsity
-    _sparsity_deps = [f"nm-magic-wand-nightly~={version}"]
+    _sparsity_deps = [f"nm-magic-wand-nightly"]
     nm_release_type = os.getenv(NM_RELEASE_TYPE)
     if nm_release_type == 'RELEASE':
-        _sparsity_deps = [f"nm-magic-wand~={version}"]
+        # gate magic-wand version in nm-vllm for release; for nightly, we always install the latest
+        magic_wand_version_dep = "0.2.2"
+        _sparsity_deps = [f"nm-magic-wand~={magic_wand_version_dep}"]
     extras_require={
         "tensorizer": ["tensorizer==2.9.0"],
         # UPSTREAM SYNC: required for sparsity

--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -10,7 +10,7 @@ from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import SamplingParams
 
 # UPSTREAM SYNC: use the current downstream.
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     "LLM",


### PR DESCRIPTION
1. bump up main to 0.4.0
2. gated nm-magic-wand version to ~=<nm-vllm version> for the release; nightly still installs the latest nm-magic-wand-nightly