### PR TITLE
Handle server startup failure in __enter__

### DIFF
--- a/tests/utils/server.py
+++ b/tests/utils/server.py
@@ -97,10 +97,15 @@ class ServerContext:
         ray.init(ignore_reinit_error=True)
         log_banner(self._logger, "server startup command args",
                    shlex.join(self._args))
-        self.server_runner = ServerRunner.remote(self._args,
-                                                 logger=self._logger)
-        ray.get(self.server_runner.ready.remote())
-        return self.server_runner
+
+        try:
+            self.server_runner = ServerRunner.remote(self._args,
+                                                     logger=self._logger)
+            ray.get(self.server_runner.ready.remote())
+            return self.server_runner
+        except Exception as e:
+            self.__exit__(*sys.exc_info())
+            raise e
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         """


### PR DESCRIPTION
With a context manager class, the `__exit__` method is not called when an exception is raised during the context manager’s `__enter__` method. This PR addresses that by manually calling that method if an exception is raised.