### PR TITLE
only run multi-gpu for python 3.10.12

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
             gitref: ${{ github.ref }}
 
             test_label_solo: aws-test-a10g-24G
-            test_label_multi: aws-test-4-a10g-96G
+            test_label_multi: ignore
             test_timeout: 480
             test_skip_list: neuralmagic/tests/skip-for-nightly.txt
 
@@ -43,7 +43,7 @@ jobs:
             gitref: ${{ github.ref }}
 
             test_label_solo: aws-test-a10g-24G
-            test_label_multi: aws-test-4-a10g-96G
+            test_label_multi: ignore
             test_timeout: 480
             test_skip_list: neuralmagic/tests/skip-for-nightly.txt
 
@@ -79,7 +79,7 @@ jobs:
             gitref: ${{ github.ref }}
 
             test_label_solo: aws-test-a10g-24G
-            test_label_multi: aws-test-4-a10g-96G
+            test_label_multi: ignore
             test_timeout: 480
             test_skip_list: neuralmagic/tests/skip-for-nightly.txt
 


### PR DESCRIPTION
SUMMARY:
* only run 4 x a10 tests for python 3.10.12

NOTE: AWS looks to be having availability issues with these instances. i'm day to day with this repo being migrated to GCP, so in the meantime let's reduce demand.

TEST PLAN:
n/a
