### PR TITLE
default nvcc_threads to 8 in order to reduce build execution time

### DIFF
--- a/.github/workflows/nm-build-test.yml
+++ b/.github/workflows/nm-build-test.yml
@@ -27,7 +27,7 @@ on:
       nvcc_threads:
         description: "number of threads nvcc build threads"
         type: string
-        default: "4"
+        default: "8"
       # test related parameters
       test_label_solo:
         description: "requested runner label (specifies instance)"


### PR DESCRIPTION
Update the nm-build-test.yml configuration to default nvcc_threads to 8 based on experiments showing that this should help reduce build execution time on the current gcp-k8s-build environment.

this change will impact workflows "using" nm-build-test.yml; nm-nightly.yml, nm-release.yml, nm-weekly.yml, nm-remote-push.yml.

