### PR TITLE
Update nm-nightly.yml

### DIFF
--- a/.github/workflows/nm-nightly.yml
+++ b/.github/workflows/nm-nightly.yml
@@ -27,7 +27,7 @@ jobs:
             test_label_solo: gcp-k8s-l4-solo
             test_label_multi: ignore
             test_timeout: 480
-            test_skip_list: neuralmagic/tests/skip-for-nightly.txt
+            test_skip_env_vars: neuralmagic/tests/test_skip_env_vars/full.txt
 
             benchmark_label: gcp-k8s-l4-solo
             benchmark_config_list_file: ./.github/data/nm_benchmark_remote_push_configs_list.txt


### PR DESCRIPTION
Updates `nm-nightly.yml` to use the new `test_skip_env_vars` attribute, instead of `test_skip_list`, for the python 3.8 block.

this is the same attribute used for the other pythons, and is what's now provided by the calling `nm-build-test.yml`