### PR TITLE
[ CI ] Disable Usage Stats in Automation

### DIFF
--- a/.github/actions/nm-set-env/action.yml
+++ b/.github/actions/nm-set-env/action.yml
@@ -39,6 +39,9 @@ runs:
       # testmo
       echo "XDG_CONFIG_HOME=/usr/local/apps" >> $GITHUB_ENV
       echo "PROJECT_ID=12" >> $GITHUB_ENV
+      # disable usage stats (writes to protected /usr/local/apps)
+      echo "VLLM_NO_USAGE_STATS=1" >> $GITHUB_ENV
+      echo "DO_NOT_TRACK=1" >> $GITHUB_ENV
     env:
         HF_TOKEN_SECRET: ${{ inputs.hf_token }}
     shell: bash


### PR DESCRIPTION
SUMMARY:
* Nightly automation has been failing with the following. This does not show up in testmo b/c its causes a `pytest.PytestUnhandledThreadExceptionWarning`

```bash
  Traceback (most recent call last):
    File "/home/runner/_work/_tool/Python/3.9.17/x64/lib/python3.9/threading.py", line 980, in _bootstrap_inner
      self.run()
    File "/home/runner/_work/_tool/Python/3.9.17/x64/lib/python3.9/threading.py", line 917, in run
      self._target(*self._args, **self._kwargs)
    File "/home/runner/_work/_tool/Python/3.9.17/x64/lib/python3.9/site-packages/vllm/usage/usage_lib.py", line 139, in _report_usage_worker
      self._report_usage_once(model_architecture, usage_context, extra_kvs)
    File "/home/runner/_work/_tool/Python/3.9.17/x64/lib/python3.9/site-packages/vllm/usage/usage_lib.py", line 179, in _report_usage_once
      self._write_to_file(data)
    File "/home/runner/_work/_tool/Python/3.9.17/x64/lib/python3.9/site-packages/vllm/usage/usage_lib.py", line 203, in _write_to_file
      os.makedirs(os.path.dirname(_USAGE_STATS_JSON_PATH), exist_ok=True)
    File "/home/runner/_work/_tool/Python/3.9.17/x64/lib/python3.9/os.py", line 215, in makedirs
      makedirs(head, exist_ok=exist_ok)
    File "/home/runner/_work/_tool/Python/3.9.17/x64/lib/python3.9/os.py", line 225, in makedirs
      mkdir(name, mode)
  PermissionError: [Errno 13] Permission denied: '/usr/local/apps'
```

* This PR disables collecting usage stats, which stops this code path from happening