### PR TITLE
set PYTHON-3-10 job to gcp

### DIFF
--- a/.github/workflows/nm-nightly.yml
+++ b/.github/workflows/nm-nightly.yml
@@ -60,7 +60,7 @@ jobs:
             python: 3.10.12
             gitref: ${{ github.ref }}
 
-            test_label_solo: aws-avx2-32G-a10g-24G
+            test_label_solo: gcp-k8s-l4-solo
             test_label_multi: ignore
             test_timeout: 480
             test_skip_env_vars: neuralmagic/tests/test_skip_env_vars/full.txt


### PR DESCRIPTION
Updated the PYTHON-3-10 job to use the same test_label_solo as the other python jobs.  This to avoid the job running out of disk space, as was happening in the g5.2xlarge aws instance it is currently using.

[PYTHON-3-10 / TEST-SOLO / TEST](https://github.com/neuralmagic/nm-vllm/actions/runs/9475210673/job/26123472789)
System.IO.IOException: No space left on device : '/opt/actions-runner/_diag/Worker_20240612-022311-utc.log'

nm remote push is currently running at https://github.com/neuralmagic/nm-vllm/actions/runs/9613896193