### PR TITLE
Force-disable upstream tracking

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -162,8 +162,7 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # Usage stats collection
     "VLLM_USAGE_STATS_SERVER":
     lambda: os.environ.get("VLLM_USAGE_STATS_SERVER", "https://stats.vllm.ai"),
-    "VLLM_NO_USAGE_STATS":
-    lambda: os.environ.get("VLLM_NO_USAGE_STATS", "0") == "1",
+    "VLLM_NO_USAGE_STATS": True,
     "VLLM_DO_NOT_TRACK": True,
     "VLLM_USAGE_SOURCE":
     lambda: os.environ.get("VLLM_USAGE_SOURCE", "production"),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -163,8 +163,10 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     "VLLM_USAGE_STATS_SERVER":
     lambda: os.environ.get("VLLM_USAGE_STATS_SERVER", "https://stats.vllm.ai"),
     # UPSTREAM SYNC: following changes force tracking to be disabled
-    "VLLM_NO_USAGE_STATS": lambda: True,
-    "VLLM_DO_NOT_TRACK": lambda: True,
+    "VLLM_NO_USAGE_STATS":
+    lambda: True,
+    "VLLM_DO_NOT_TRACK":
+    lambda: True,
     "VLLM_USAGE_SOURCE":
     lambda: os.environ.get("VLLM_USAGE_SOURCE", "production"),
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -163,8 +163,8 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     "VLLM_USAGE_STATS_SERVER":
     lambda: os.environ.get("VLLM_USAGE_STATS_SERVER", "https://stats.vllm.ai"),
     # UPSTREAM SYNC: following changes force tracking to be disabled
-    "VLLM_NO_USAGE_STATS": True,
-    "VLLM_DO_NOT_TRACK": True,
+    "VLLM_NO_USAGE_STATS": lambda: True,
+    "VLLM_DO_NOT_TRACK": lambda: True,
     "VLLM_USAGE_SOURCE":
     lambda: os.environ.get("VLLM_USAGE_SOURCE", "production"),
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -162,6 +162,7 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # Usage stats collection
     "VLLM_USAGE_STATS_SERVER":
     lambda: os.environ.get("VLLM_USAGE_STATS_SERVER", "https://stats.vllm.ai"),
+    # UPSTREAM SYNC: following changes force tracking to be disabled
     "VLLM_NO_USAGE_STATS": True,
     "VLLM_DO_NOT_TRACK": True,
     "VLLM_USAGE_SOURCE":

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
     S3_ENDPOINT_URL: Optional[str] = None
     VLLM_CONFIG_ROOT: str = ""
     VLLM_USAGE_STATS_SERVER: str = "https://stats.vllm.ai"
-    VLLM_NO_USAGE_STATS: bool = False
-    VLLM_DO_NOT_TRACK: bool = False
+    VLLM_NO_USAGE_STATS: bool = True
+    VLLM_DO_NOT_TRACK: bool = True
     VLLM_USAGE_SOURCE: str = ""
     VLLM_CONFIGURE_LOGGING: int = 1
     VLLM_LOGGING_LEVEL: str = "INFO"

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -164,9 +164,7 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda: os.environ.get("VLLM_USAGE_STATS_SERVER", "https://stats.vllm.ai"),
     "VLLM_NO_USAGE_STATS":
     lambda: os.environ.get("VLLM_NO_USAGE_STATS", "0") == "1",
-    "VLLM_DO_NOT_TRACK":
-    lambda: (os.environ.get("VLLM_DO_NOT_TRACK", None) or os.environ.get(
-        "DO_NOT_TRACK", None) or "0") == "1",
+    "VLLM_DO_NOT_TRACK": True,
     "VLLM_USAGE_SOURCE":
     lambda: os.environ.get("VLLM_USAGE_SOURCE", "production"),
 


### PR DESCRIPTION
This PR force-disables upstream tracking by forcing `VLLM_DO_NOT_TRACK` and `VLLM_NO_USAGE_STATS` to be `True` (disable data collection) rather than inspecting the environment variable.

An alternative approach could be to update the definition of `is_usage_stats_enabled` (in [`vllm/usage/usage_lib.py:29`](https://github.com/neuralmagic/nm-vllm/blob/main/vllm/usage/usage_lib.py#L29)) to always return `False` and set the `global _USAGE_STATS_ENABLED` to be `False`.