### PR TITLE
add some guards for pypi push

### DIFF
--- a/.github/workflows/nm-build-test.yml
+++ b/.github/workflows/nm-build-test.yml
@@ -9,10 +9,7 @@ on:
         default: "REMOTE"
       push_binaries_to_pypi:
         description: "When set to true, built wheels and tar.gz will be pushed to neuralmagic pypi if all tests pass"
-        type: choice
-        options:
-          - 'yes'
-          - 'no'
+        type: string
         default: 'no'
       python:
         description: "python version, e.g. 3.10.12"

--- a/.github/workflows/nm-build-test.yml
+++ b/.github/workflows/nm-build-test.yml
@@ -7,6 +7,13 @@ on:
         description: "categories: REMOTE, NIGHTLY, WEEKLY, RELEASE"
         type: string
         default: "REMOTE"
+      push_binaries_to_pypi:
+        description: "When set to true, built wheels and tar.gz will be pushed to neuralmagic pypi if all tests pass"
+        type: choice
+        options:
+          - 'yes'
+          - 'no'
+        default: 'no'
       python:
         description: "python version, e.g. 3.10.12"
         type: string
@@ -121,17 +128,6 @@ jobs:
     #         test_skip_env_vars: ${{ inputs.test_skip_env_vars }}
     #     secrets: inherit
 
-    UPLOAD:
-        needs: [TEST-SOLO]
-        if: contains(fromJSON('["NIGHTLY", "WEEKLY", "RELEASE"]'), inputs.wf_category)
-        uses: ./.github/workflows/nm-upload-assets-to-gcp.yml
-        with:
-            label: ${{ inputs.build_label }}
-            timeout: ${{ inputs.build_timeout }}
-            gitref: ${{ github.ref }}
-            python: ${{ inputs.python }}
-        secrets: inherit
-
     BENCHMARK:
         needs: [BUILD]
         if: success()
@@ -158,3 +154,14 @@ jobs:
         whl: ${{ needs.BUILD.outputs.whl }}
         lm_eval_configuration: ${{ inputs.lm_eval_configuration }}
       secrets: inherit
+
+    UPLOAD:
+        needs: [TEST-SOLO, BENCHMARK, LM-EVAL-SOLO]
+        if: ${{ contains(fromJSON('["NIGHTLY", "WEEKLY", "RELEASE"]'), inputs.wf_category) && inputs.push_binaries_to_pypi == 'yes' }}
+        uses: ./.github/workflows/nm-upload-assets-to-gcp.yml
+        with:
+            label: ${{ inputs.build_label }}
+            timeout: ${{ inputs.build_timeout }}
+            gitref: ${{ github.ref }}
+            python: ${{ inputs.python }}
+        secrets: inherit

--- a/.github/workflows/nm-nightly.yml
+++ b/.github/workflows/nm-nightly.yml
@@ -14,13 +14,13 @@ on:
                     - 'true'
                     - 'false'
                 default: 'false'
-      push_binaries_to_pypi:
-        description: "When set to yes, built wheels and tar.gz will be pushed to neuralmagic pypi if all tests pass"
-        type: choice
-        options:
-          - 'yes'
-          - 'no'
-        default: 'yes'
+            push_binaries_to_pypi:
+                description: "When set to yes, built wheels and tar.gz will be pushed to neuralmagic pypi if all tests pass"
+                type: choice
+                options:
+                    - 'yes'
+                    - 'no'
+                default: 'yes'
 
 jobs:
 

--- a/.github/workflows/nm-nightly.yml
+++ b/.github/workflows/nm-nightly.yml
@@ -16,10 +16,7 @@ on:
                 default: 'false'
             push_binaries_to_pypi:
                 description: "When set to yes, built wheels and tar.gz will be pushed to neuralmagic pypi if all tests pass"
-                type: choice
-                options:
-                    - 'yes'
-                    - 'no'
+                type: string
                 default: 'yes'
 
 jobs:

--- a/.github/workflows/nm-nightly.yml
+++ b/.github/workflows/nm-nightly.yml
@@ -14,6 +14,13 @@ on:
                     - 'true'
                     - 'false'
                 default: 'false'
+      push_binaries_to_pypi:
+        description: "When set to yes, built wheels and tar.gz will be pushed to neuralmagic pypi if all tests pass"
+        type: choice
+        options:
+          - 'yes'
+          - 'no'
+        default: 'yes'
 
 jobs:
 
@@ -23,6 +30,7 @@ jobs:
             wf_category: NIGHTLY
             python: 3.8.17
             gitref: ${{ github.ref }}
+            push_binaries_to_pypi: ${{ inputs.push_binaries_to_pypi }}
 
             test_label_solo: gcp-k8s-l4-solo
             test_label_multi: ignore
@@ -45,6 +53,7 @@ jobs:
             wf_category: NIGHTLY
             python: 3.9.17
             gitref: ${{ github.ref }}
+            push_binaries_to_pypi: ${{ inputs.push_binaries_to_pypi }}
 
             test_label_solo: gcp-k8s-l4-solo
             test_label_multi: ignore
@@ -67,6 +76,7 @@ jobs:
             wf_category: NIGHTLY
             python: 3.10.12
             gitref: ${{ github.ref }}
+            push_binaries_to_pypi: ${{ inputs.push_binaries_to_pypi }}
 
             test_label_solo: gcp-k8s-l4-solo
             test_label_multi: ignore
@@ -89,6 +99,7 @@ jobs:
             wf_category: NIGHTLY
             python: 3.11.4
             gitref: ${{ github.ref }}
+            push_binaries_to_pypi: ${{ inputs.push_binaries_to_pypi }}
 
             test_label_solo: gcp-k8s-l4-solo
             test_label_multi: ignore

--- a/.github/workflows/nm-release.yml
+++ b/.github/workflows/nm-release.yml
@@ -10,6 +10,13 @@ on:
           - 'true'
           - 'false'
         default: 'false'
+      push_binaries_to_pypi:
+        description: "When set to yes, built wheels and tar.gz will be pushed to neuralmagic pypi if all tests pass"
+        type: choice
+        options:
+          - 'yes'
+          - 'no'
+        default: 'no'
 
 jobs:
 
@@ -19,6 +26,7 @@ jobs:
       wf_category: 'RELEASE'
       python: 3.8.17
       gitref: ${{ github.ref }}
+      push_binaries_to_pypi: ${{ inputs.push_binaries_to_pypi }}
 
       test_label_solo: gcp-k8s-l4-solo
       test_label_multi: ignore
@@ -41,6 +49,7 @@ jobs:
       wf_category: 'RELEASE'
       python: 3.9.17
       gitref: ${{ github.ref }}
+      push_binaries_to_pypi: ${{ inputs.push_binaries_to_pypi }}
 
       test_label_solo: gcp-k8s-l4-solo
       test_label_multi: ignore
@@ -63,6 +72,7 @@ jobs:
       wf_category: 'RELEASE'
       python: 3.10.12
       gitref: ${{ github.ref }}
+      push_binaries_to_pypi: ${{ inputs.push_binaries_to_pypi }}
 
       test_label_solo: gcp-k8s-l4-solo
       test_label_multi: ignore
@@ -85,6 +95,7 @@ jobs:
       wf_category: 'RELEASE'
       python: 3.11.4
       gitref: ${{ github.ref }}
+      push_binaries_to_pypi: ${{ inputs.push_binaries_to_pypi }}
 
       test_label_solo: gcp-k8s-l4-solo
       test_label_multi: ignore

--- a/.github/workflows/nm-release.yml
+++ b/.github/workflows/nm-release.yml
@@ -12,10 +12,7 @@ on:
         default: 'false'
       push_binaries_to_pypi:
         description: "When set to yes, built wheels and tar.gz will be pushed to neuralmagic pypi if all tests pass"
-        type: choice
-        options:
-          - 'yes'
-          - 'no'
+        type: string
         default: 'no'
 
 jobs:

--- a/.github/workflows/nm-remote-push.yml
+++ b/.github/workflows/nm-remote-push.yml
@@ -17,6 +17,7 @@ jobs:
         with:
             python: 3.8.17
             gitref: ${{ github.ref }}
+            push_binaries_to_pypi: 'no'
 
             test_label_solo: gcp-k8s-l4-solo
             test_label_multi: ignore
@@ -37,6 +38,7 @@ jobs:
         with:
             python: 3.9.17
             gitref: ${{ github.ref }}
+            push_binaries_to_pypi: 'no'
 
             test_label_solo: gcp-k8s-l4-solo
             test_label_multi: ignore
@@ -57,6 +59,7 @@ jobs:
         with:
             python: 3.10.12
             gitref: ${{ github.ref }}
+            push_binaries_to_pypi: 'no'
 
             test_label_solo: gcp-k8s-l4-solo
             test_label_multi: ignore
@@ -77,6 +80,7 @@ jobs:
         with:
             python: 3.11.4
             gitref: ${{ github.ref }}
+            push_binaries_to_pypi: 'no'
 
             test_label_solo: gcp-k8s-l4-solo
             test_label_multi: ignore

--- a/.github/workflows/nm-weekly.yml
+++ b/.github/workflows/nm-weekly.yml
@@ -23,6 +23,7 @@ jobs:
       wf_category: WEEKLY
       python: 3.10.12
       gitref: ${{ github.ref }}
+      push_binaries_to_pypi: 'no'
 
       test_label_solo: aws-avx2-32G-a10g-24G
       test_label_multi: aws-avx2-192G-4-a10g-96G


### PR DESCRIPTION
1. Added an input argument push_binaries_to_pypi to allow not pushing to nm pypi automatically. It's 'yes' for nightly and 'no' for release by default.

2. Require all tests to pass before uploading.