### PR TITLE
[WIP] Fix for FP8 checkpoints with fused scales

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -389,11 +389,12 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         if loaded_shard_id is None:
             # Loaded weight is already packed.
             if output_dim is None:
-                assert param_data.shape == loaded_weight.shape
-                param_data.copy_(loaded_weight)
+                temp = loaded_weight.repeat(param_data.shape)
+                assert param_data.shape == temp.shape
+                param_data.copy_(temp)
                 return
             current_shard_offset = 0
-            shard_offsets: List[Tuple[int, int, int]] = []
+            shard_offsets = []
             for i, output_size in enumerate(self.output_sizes):
                 shard_offsets.append((i, current_shard_offset, output_size))
                 current_shard_offset += output_size
@@ -573,8 +574,9 @@ class QKVParallelLinear(ColumnParallelLinear):
         if loaded_shard_id is None:
             # Loaded weight is already packed.
             if output_dim is None:
-                assert param_data.shape == loaded_weight.shape
-                param_data.copy_(loaded_weight)
+                temp = loaded_weight.repeat(param_data.shape)
+                assert param_data.shape == temp.shape
+                param_data.copy_(temp)
                 return
             shard_offsets = [
                 # (shard_id, shard_offset, shard_size)


### PR DESCRIPTION
Found when loading FP8 quantized Phi-3 because it has merged qkv and up_gate: https://huggingface.co/nm-testing/Phi-3-mini-128k-instruct-FP8

Basically FP8 always makes scales for each shard and we don't deal with layers that are already merged
```
param_data.shape=torch.Size([2]) loaded_weight.shape=torch.Size([])
param_data.shape=torch.Size([3]) loaded_weight.shape=torch.Size([])
```

We always assume those scales will be filled and we take the max to save the single value for the merged layer in `process_weights_after_loading`

This PR just repeats the merged scale during weight loading in MergedColumnParallelLinear and QKVParallelLinear
