### PR TITLE
Fix docker build failure in nighlty

### DIFF
--- a/.github/workflows/nm-build-test.yml
+++ b/.github/workflows/nm-build-test.yml
@@ -173,7 +173,7 @@ jobs:
 
     # update docker
     DOCKER:
-        needs: [BUILD]
+        needs: [BUILD, UPLOAD]
         if: ${{ inputs.wf_category != 'REMOTE' }}
         uses: ./.github/workflows/publish-docker.yml
         with:

--- a/.github/workflows/nm-upload-assets-to-gcp.yml
+++ b/.github/workflows/nm-upload-assets-to-gcp.yml
@@ -108,15 +108,15 @@ jobs:
 #                    https://api.github.com/repos/neuralmagic/stratus/dispatches \
 #                    -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"
 
-            - name: trigger stratus nm-pypi update workflow
-              uses: actions/github-script@v6
-              with:
-                  github-token: ${{ secrets.CICD_GITHUB_PAT }}
-              script: |
-                  const result = await github.rest.actions.createWorkflowDispatch({
-                  owner: 'neuralmagic',
-                  repo: 'stratus',
-                  workflow_id: 'nm-pypi-update.yml'
-                  ref: 'trigger'
-                })
-                console.log(result)
+           - name: trigger stratus nm-pypi update workflow
+             uses: actions/github-script@v6
+             with:
+                 github-token: ${{ secrets.CICD_GITHUB_PAT }}
+             script: |
+                 const result = await github.rest.actions.createWorkflowDispatch({
+                   owner: 'neuralmagic',
+                   repo: 'stratus',
+                   workflow_id: 'nm-pypi-update.yml'
+                   ref: 'trigger'
+                 })
+                 console.log(result)

--- a/.github/workflows/nm-upload-assets-to-gcp.yml
+++ b/.github/workflows/nm-upload-assets-to-gcp.yml
@@ -117,6 +117,6 @@ jobs:
                   owner: 'neuralmagic',
                   repo: 'stratus',
                   workflow_id: 'nm-pypi-update.yml'
-                  ref: 'docker'
+                  ref: 'trigger'
                 })
                 console.log(result)

--- a/.github/workflows/nm-upload-assets-to-gcp.yml
+++ b/.github/workflows/nm-upload-assets-to-gcp.yml
@@ -70,3 +70,18 @@ jobs:
             - name: cp assets
               id: cp-assets
               uses: ./.github/actions/nm-cp-assets/
+
+            - name: trigger stratus nm-pypi update workflow
+              run: |
+                  # Set the required variables
+                  event_type="trigger-workflow" 
+                  service=${{ github.event.inputs.target_service }}"
+                  version="${{ github.event.inputs.target_version }}"
+  
+                  curl -L \
+                    -X POST \
+                    -H "Accept: application/vnd.github+json" \
+                    -H "Authorization: Bearer ${{ secrets.CICD_GITHUB_PAT }}" \
+                    -H "X-GitHub-Api-Version: 2022-11-28" \
+                    https://api.github.com/repos/neuralmagic/stratus/dispatches \
+                    -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"

--- a/.github/workflows/nm-upload-assets-to-gcp.yml
+++ b/.github/workflows/nm-upload-assets-to-gcp.yml
@@ -65,6 +65,19 @@ jobs:
                 ref: "docker"
                 submodules: recursive
 
+            - name: trigger stratus nm-pypi update workflow
+              uses: actions/github-script@v6
+              with:
+                github-token: ${{ secrets.CICD_GITHUB_PAT }}
+                script: |
+                  const result = await github.rest.actions.createWorkflowDispatch({
+                    owner: 'neuralmagic',
+                    repo: 'stratus',
+                    workflow_id: 'nm-pypi-update.yml'
+                    ref: 'trigger'
+                  })
+                  console.log(result)
+
 #            - name: setenv
 #              id: setenv
 #              uses: ./.github/actions/nm-set-env/
@@ -107,16 +120,3 @@ jobs:
 #                    -H "X-GitHub-Api-Version: 2022-11-28" \
 #                    https://api.github.com/repos/neuralmagic/stratus/dispatches \
 #                    -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"
-
-           - name: trigger stratus nm-pypi update workflow
-             uses: actions/github-script@v6
-             with:
-                 github-token: ${{ secrets.CICD_GITHUB_PAT }}
-                 script: |
-                   const result = await github.rest.actions.createWorkflowDispatch({
-                     owner: 'neuralmagic',
-                     repo: 'stratus',
-                     workflow_id: 'nm-pypi-update.yml'
-                     ref: 'trigger'
-                   })
-                   console.log(result)

--- a/.github/workflows/nm-upload-assets-to-gcp.yml
+++ b/.github/workflows/nm-upload-assets-to-gcp.yml
@@ -58,19 +58,6 @@ jobs:
                 ref: ${{ inputs.gitref }}
                 submodules: recursive
 
-            - name: trigger stratus nm-pypi update workflow
-              uses: actions/github-script@v6
-              with:
-                github-token: ${{ secrets.CICD_GITHUB_PAT }}
-                script: |
-                  const result = await github.rest.actions.createWorkflowDispatch({
-                    owner: 'neuralmagic',
-                    repo: 'stratus',
-                    workflow_id: 'nm-pypi-update.yml',
-                    ref: 'trigger'
-                  })
-                  console.log(result)
-
             - name: setenv
               id: setenv
               uses: ./.github/actions/nm-set-env/

--- a/.github/workflows/nm-upload-assets-to-gcp.yml
+++ b/.github/workflows/nm-upload-assets-to-gcp.yml
@@ -32,17 +32,11 @@ on:
                 type: string
                 required: true
 
-    push:
-        branches:
-          - docker
-
 jobs:
 
     PUBLISH:
-        #runs-on: ${{ inputs.label }}
-        #timeout-minutes: ${{ fromJson(inputs.timeout) }}
-        runs-on: "gcp-k8s-util"
-        timeout-minutes: 30
+        runs-on: ${{ inputs.label }}
+        timeout-minutes: ${{ fromJson(inputs.timeout) }}
 
         permissions:
             contents: 'read'
@@ -61,8 +55,7 @@ jobs:
               uses: actions/checkout@v4
               with:
                 fetch-depth: 0
-                #ref: ${{ inputs.gitref }}
-                ref: "docker"
+                ref: ${{ inputs.gitref }}
                 submodules: recursive
 
             - name: trigger stratus nm-pypi update workflow
@@ -78,45 +71,43 @@ jobs:
                   })
                   console.log(result)
 
-#            - name: setenv
-#              id: setenv
-#              uses: ./.github/actions/nm-set-env/
+            - name: setenv
+              id: setenv
+              uses: ./.github/actions/nm-set-env/
 
-#            - name: download assets
-#              id: download_whl
-#              uses: actions/download-artifact@v4
-#              with:
-#                  path: assets
+            - name: download assets
+              id: download_whl
+              uses: actions/download-artifact@v4
+              with:
+                  path: assets
 
-#            # GCP
-#            - name: 'Authenticate to Google Cloud'
-#              id: auth
-#              uses: google-github-actions/auth@v2.1.3
-#              with:
-#                  project_id: ${{ secrets.GCP_PROJECT }}
-#                  workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-#                  service_account: ${{ secrets.NM_PYPI_SA }}
+            # GCP
+            - name: 'Authenticate to Google Cloud'
+              id: auth
+              uses: google-github-actions/auth@v2.1.3
+              with:
+                  project_id: ${{ secrets.GCP_PROJECT }}
+                  workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+                  service_account: ${{ secrets.NM_PYPI_SA }}
 
-#            - name: 'Set up Cloud SDK'
-#              uses: 'google-github-actions/setup-gcloud@v2'
-#              with:
-#                  version: '>= 473.0.0'
+            - name: 'Set up Cloud SDK'
+              uses: 'google-github-actions/setup-gcloud@v2'
+              with:
+                  version: '>= 473.0.0'
 
-#            - name: cp assets
-#              id: cp-assets
-#              uses: ./.github/actions/nm-cp-assets/
+            - name: cp assets
+              id: cp-assets
+              uses: ./.github/actions/nm-cp-assets/
 
-#            - name: trigger stratus nm-pypi update workflow
-#              run: |
-#                  # Set the required variables
-#                  event_type="trigger-workflow" 
-#                  service=${{ github.event.inputs.target_service }}"
-#                  version="${{ github.event.inputs.target_version }}"
-  
-#                  curl -L \
-#                    -X POST \
-#                    -H "Accept: application/vnd.github+json" \
-#                    -H "Authorization: Bearer ${{ secrets.CICD_GITHUB_PAT }}" \
-#                    -H "X-GitHub-Api-Version: 2022-11-28" \
-#                    https://api.github.com/repos/neuralmagic/stratus/dispatches \
-#                    -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"
+            - name: trigger stratus nm-pypi update workflow to update nm-pypi index
+              uses: actions/github-script@v6
+              with:
+                github-token: ${{ secrets.CICD_GITHUB_PAT }}
+                script: |
+                  const result = await github.rest.actions.createWorkflowDispatch({
+                    owner: 'neuralmagic',
+                    repo: 'stratus',
+                    workflow_id: 'nm-pypi-update.yml',
+                    ref: 'main'
+                  })
+                  console.log(result)

--- a/.github/workflows/nm-upload-assets-to-gcp.yml
+++ b/.github/workflows/nm-upload-assets-to-gcp.yml
@@ -42,7 +42,7 @@ jobs:
         #runs-on: ${{ inputs.label }}
         #timeout-minutes: ${{ fromJson(inputs.timeout) }}
         runs-on: "gcp-k8s-util"
-        timeout-minutes: ${{ fromJson("30") }}
+        timeout-minutes: 30
 
         permissions:
             contents: 'read'

--- a/.github/workflows/nm-upload-assets-to-gcp.yml
+++ b/.github/workflows/nm-upload-assets-to-gcp.yml
@@ -17,11 +17,32 @@ on:
                 type: string
                 required: true
 
+    workflow_dispatch:
+        inputs:
+            label:
+                description: "requested runner label (specifies instance)"
+                type: string
+                required: true
+            timeout:
+                description: "time limit for run in minutes "
+                type: string
+                required: true
+            gitref:
+                description: 'git commit hash or branch name'
+                type: string
+                required: true
+
+    push:
+        branches:
+          - docker
+
 jobs:
 
     PUBLISH:
-        runs-on: ${{ inputs.label }}
-        timeout-minutes: ${{ fromJson(inputs.timeout) }}
+        #runs-on: ${{ inputs.label }}
+        #timeout-minutes: ${{ fromJson(inputs.timeout) }}
+        runs-on: "gcp-k8s-util"
+        timeout-minutes: "60"
 
         permissions:
             contents: 'read'
@@ -40,36 +61,37 @@ jobs:
               uses: actions/checkout@v4
               with:
                 fetch-depth: 0
-                ref: ${{ inputs.gitref }}
+                #ref: ${{ inputs.gitref }}
+                ref: "docker"
                 submodules: recursive
 
-            - name: setenv
-              id: setenv
-              uses: ./.github/actions/nm-set-env/
+#            - name: setenv
+#              id: setenv
+#              uses: ./.github/actions/nm-set-env/
 
-            - name: download assets
-              id: download_whl
-              uses: actions/download-artifact@v4
-              with:
-                  path: assets
+#            - name: download assets
+#              id: download_whl
+#              uses: actions/download-artifact@v4
+#              with:
+#                  path: assets
 
-            # GCP
-            - name: 'Authenticate to Google Cloud'
-              id: auth
-              uses: google-github-actions/auth@v2.1.3
-              with:
-                  project_id: ${{ secrets.GCP_PROJECT }}
-                  workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-                  service_account: ${{ secrets.NM_PYPI_SA }}
+#            # GCP
+#            - name: 'Authenticate to Google Cloud'
+#              id: auth
+#              uses: google-github-actions/auth@v2.1.3
+#              with:
+#                  project_id: ${{ secrets.GCP_PROJECT }}
+#                  workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+#                  service_account: ${{ secrets.NM_PYPI_SA }}
 
-            - name: 'Set up Cloud SDK'
-              uses: 'google-github-actions/setup-gcloud@v2'
-              with:
-                  version: '>= 473.0.0'
+#            - name: 'Set up Cloud SDK'
+#              uses: 'google-github-actions/setup-gcloud@v2'
+#              with:
+#                  version: '>= 473.0.0'
 
-            - name: cp assets
-              id: cp-assets
-              uses: ./.github/actions/nm-cp-assets/
+#            - name: cp assets
+#              id: cp-assets
+#              uses: ./.github/actions/nm-cp-assets/
 
             - name: trigger stratus nm-pypi update workflow
               run: |

--- a/.github/workflows/nm-upload-assets-to-gcp.yml
+++ b/.github/workflows/nm-upload-assets-to-gcp.yml
@@ -42,7 +42,7 @@ jobs:
         #runs-on: ${{ inputs.label }}
         #timeout-minutes: ${{ fromJson(inputs.timeout) }}
         runs-on: "gcp-k8s-util"
-        timeout-minutes: "60"
+        timeout-minutes: ${{ fromJson("30") }}
 
         permissions:
             contents: 'read'

--- a/.github/workflows/nm-upload-assets-to-gcp.yml
+++ b/.github/workflows/nm-upload-assets-to-gcp.yml
@@ -73,7 +73,7 @@ jobs:
                   const result = await github.rest.actions.createWorkflowDispatch({
                     owner: 'neuralmagic',
                     repo: 'stratus',
-                    workflow_id: 'nm-pypi-update.yml'
+                    workflow_id: 'nm-pypi-update.yml',
                     ref: 'trigger'
                   })
                   console.log(result)

--- a/.github/workflows/nm-upload-assets-to-gcp.yml
+++ b/.github/workflows/nm-upload-assets-to-gcp.yml
@@ -93,17 +93,30 @@ jobs:
 #              id: cp-assets
 #              uses: ./.github/actions/nm-cp-assets/
 
-            - name: trigger stratus nm-pypi update workflow
-              run: |
-                  # Set the required variables
-                  event_type="trigger-workflow" 
-                  service=${{ github.event.inputs.target_service }}"
-                  version="${{ github.event.inputs.target_version }}"
+#            - name: trigger stratus nm-pypi update workflow
+#              run: |
+#                  # Set the required variables
+#                  event_type="trigger-workflow" 
+#                  service=${{ github.event.inputs.target_service }}"
+#                  version="${{ github.event.inputs.target_version }}"
   
-                  curl -L \
-                    -X POST \
-                    -H "Accept: application/vnd.github+json" \
-                    -H "Authorization: Bearer ${{ secrets.CICD_GITHUB_PAT }}" \
-                    -H "X-GitHub-Api-Version: 2022-11-28" \
-                    https://api.github.com/repos/neuralmagic/stratus/dispatches \
-                    -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"
+#                  curl -L \
+#                    -X POST \
+#                    -H "Accept: application/vnd.github+json" \
+#                    -H "Authorization: Bearer ${{ secrets.CICD_GITHUB_PAT }}" \
+#                    -H "X-GitHub-Api-Version: 2022-11-28" \
+#                    https://api.github.com/repos/neuralmagic/stratus/dispatches \
+#                    -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"service\": \"$service\", \"version\": \"$version\", \"unit\": false, \"integration\": true}}"
+
+            - name: trigger stratus nm-pypi update workflow
+              uses: actions/github-script@v6
+              with:
+                  github-token: ${{ secrets.CICD_GITHUB_PAT }}
+              script: |
+                  const result = await github.rest.actions.createWorkflowDispatch({
+                  owner: 'neuralmagic',
+                  repo: 'stratus',
+                  workflow_id: 'nm-pypi-update.yml'
+                  ref: 'docker'
+                })
+                console.log(result)

--- a/.github/workflows/nm-upload-assets-to-gcp.yml
+++ b/.github/workflows/nm-upload-assets-to-gcp.yml
@@ -112,11 +112,11 @@ jobs:
              uses: actions/github-script@v6
              with:
                  github-token: ${{ secrets.CICD_GITHUB_PAT }}
-             script: |
-                 const result = await github.rest.actions.createWorkflowDispatch({
-                   owner: 'neuralmagic',
-                   repo: 'stratus',
-                   workflow_id: 'nm-pypi-update.yml'
-                   ref: 'trigger'
-                 })
-                 console.log(result)
+                 script: |
+                   const result = await github.rest.actions.createWorkflowDispatch({
+                     owner: 'neuralmagic',
+                     repo: 'stratus',
+                     workflow_id: 'nm-pypi-update.yml'
+                     ref: 'trigger'
+                   })
+                   console.log(result)


### PR DESCRIPTION
Fixed two issues:

1. Trigger nm pypi update workflow in stratus automatically after wheels are uploaded to GCP.
2. Docker build step should only run after the upload step is finished successfully.

An example run from nm-vllm: https://github.com/neuralmagic/nm-vllm/actions/runs/9810788569

which triggers stratus nm pypi update workflow run: https://github.com/neuralmagic/stratus/actions/runs/9810806638