### PR TITLE
make venv input optional

### DIFF
--- a/.github/actions/nm-benchmark/action.yml
+++ b/.github/actions/nm-benchmark/action.yml
@@ -12,7 +12,8 @@ inputs:
     required: true
   venv:
     description: 'name for python virtual environment'
-    required: true
+    required: false
+    default: ""
 runs:
   using: composite
   steps:

--- a/.github/actions/nm-benchmark/action.yml
+++ b/.github/actions/nm-benchmark/action.yml
@@ -7,13 +7,6 @@ inputs:
   output_directory:
     description: 'output directory to store the benchmark results'
     required: true
-  python:
-    description: 'python version, e.g. 3.10.12'
-    required: true
-  venv:
-    description: 'name for python virtual environment'
-    required: false
-    default: ""
 runs:
   using: composite
   steps:
@@ -23,11 +16,6 @@ runs:
       # move source directories
       mv vllm vllm-ignore || echo "no 'vllm' folder to move"
       mv csrc csrc-ignore || echo "no 'csrc' folder to move"
-      if [ ! -z "${{ inputs.venv }}" ]; then
-        COMMIT=${{ github.sha }}
-        VENV="${{ inputs.venv }}-${COMMIT:0:7}"
-        source $(pyenv root)/versions/${{ inputs.python }}/envs/${VENV}/bin/activate
-      fi
       pip3 install -r neuralmagic/benchmarks/requirements-benchmark.txt
       SUCCESS=0
       .github/scripts/nm-run-benchmarks.sh ${{ inputs.benchmark_config_list_file }} ${{ inputs.output_directory }} || SUCCESS=$?

--- a/.github/actions/nm-install-whl/action.yml
+++ b/.github/actions/nm-install-whl/action.yml
@@ -6,7 +6,8 @@ inputs:
     required: true
   venv:
     description: 'name for python virtual environment'
-    required: true
+    required: false
+    default: ""
 runs:
   using: composite
   steps:

--- a/.github/actions/nm-install-whl/action.yml
+++ b/.github/actions/nm-install-whl/action.yml
@@ -1,13 +1,5 @@
 name: install whl
 description: 'installs found whl based on python version into specified venv'
-inputs:
-  python:
-    description: 'python version, e.g. 3.10.12'
-    required: true
-  venv:
-    description: 'name for python virtual environment'
-    required: false
-    default: ""
 runs:
   using: composite
   steps:
@@ -17,11 +9,6 @@ runs:
         mv vllm vllm-ignore
         mv csrc csrc-ignore
         # activate and install
-        if [ ! -z "${{ inputs.venv }}" ]; then
-          COMMIT=${{ github.sha }}
-          VENV="${{ inputs.venv }}-${COMMIT:0:7}"
-          source $(pyenv root)/versions/${{ inputs.python }}/envs/${VENV}/bin/activate
-        fi
         pip3 install -r requirements-dev.txt
         WHL=$(find . -type f -iname "nm_vllm*.whl")
         WHL_BASENAME=$(basename ${WHL})

--- a/.github/actions/nm-lm-eval/action.yml
+++ b/.github/actions/nm-lm-eval/action.yml
@@ -6,7 +6,8 @@ inputs:
     required: true
   venv:
     description: 'name for python virtual environment'
-    required: true
+    required: false
+    default: ""
   lm_eval_configuration:
     description: 'file containing test configuration'
     required: true
@@ -15,7 +16,7 @@ runs:
   steps:
   - id: lm-eval
     run: |
-      if [ -n "${{ inputs.venv }}" ]; then
+      if [ ! -z "${{ inputs.venv }}" ]; then
         COMMIT=${{ github.sha }}
         VENV="${{ inputs.venv }}-${COMMIT:0:7}"
         source $(pyenv root)/versions/${{ inputs.python }}/envs/${VENV}/bin/activate

--- a/.github/actions/nm-lm-eval/action.yml
+++ b/.github/actions/nm-lm-eval/action.yml
@@ -1,13 +1,6 @@
 name: run lm-eval accuracy test
 description: 'run lm-eval accuracy test'
 inputs:
-  python:
-    description: 'python version, e.g. 3.10.12'
-    required: true
-  venv:
-    description: 'name for python virtual environment'
-    required: false
-    default: ""
   lm_eval_configuration:
     description: 'file containing test configuration'
     required: true
@@ -16,12 +9,6 @@ runs:
   steps:
   - id: lm-eval
     run: |
-      if [ ! -z "${{ inputs.venv }}" ]; then
-        COMMIT=${{ github.sha }}
-        VENV="${{ inputs.venv }}-${COMMIT:0:7}"
-        source $(pyenv root)/versions/${{ inputs.python }}/envs/${VENV}/bin/activate
-      fi
-
       pip3 install git+https://github.com/EleutherAI/lm-evaluation-harness.git@262f879a06aa5de869e5dd951d0ff2cf2f9ba380
       pip3 install pytest openai==1.3.9
 

--- a/.github/actions/nm-produce-gha-benchmark-json/action.yml
+++ b/.github/actions/nm-produce-gha-benchmark-json/action.yml
@@ -17,7 +17,8 @@ inputs:
     required: true
   venv:
     description: 'name for python virtual environment'
-    required: true
+    required: false
+    default: ""
 runs:
   using: composite
   steps:

--- a/.github/workflows/nm-benchmark.yml
+++ b/.github/workflows/nm-benchmark.yml
@@ -122,7 +122,6 @@ jobs:
         uses: ./.github/actions/nm-install-whl/
         with:
             python: ${{ inputs.python }}
-            venv:
 
       - name: run benchmarks
         uses: ./.github/actions/nm-benchmark/
@@ -130,7 +129,6 @@ jobs:
           benchmark_config_list_file: ${{ inputs.benchmark_config_list_file }}
           output_directory: benchmark-results
           python: ${{ inputs.python }}
-          venv:
 
       - name: store benchmark result artifacts
         if: success()
@@ -171,7 +169,6 @@ jobs:
           # Metrics that we only want to observe are stored here
           observation_metrics_output_file_path: gh-action-benchmark-jsons/observation_metrics.json
           python: ${{ inputs.python }}
-          venv:
 
       - name: set gh action benchmark input artifact name
         id: set_gh_action_benchmark_input_artifact_name

--- a/.github/workflows/nm-benchmark.yml
+++ b/.github/workflows/nm-benchmark.yml
@@ -120,15 +120,12 @@ jobs:
       - name: install whl
         id: install_whl
         uses: ./.github/actions/nm-install-whl/
-        with:
-            python: ${{ inputs.python }}
 
       - name: run benchmarks
         uses: ./.github/actions/nm-benchmark/
         with:
           benchmark_config_list_file: ${{ inputs.benchmark_config_list_file }}
           output_directory: benchmark-results
-          python: ${{ inputs.python }}
 
       - name: store benchmark result artifacts
         if: success()

--- a/.github/workflows/nm-lm-eval.yml
+++ b/.github/workflows/nm-lm-eval.yml
@@ -105,11 +105,8 @@ jobs:
       - name: install whl
         id: install_whl
         uses: ./.github/actions/nm-install-whl/
-        with:
-            python: ${{ inputs.python }}
 
       - name: run lm-eval-accuracy
         uses: ./.github/actions/nm-lm-eval/
         with:
-          python: ${{ inputs.python }}
           lm_eval_configuration: ${{ inputs.lm_eval_configuration }}

--- a/.github/workflows/nm-lm-eval.yml
+++ b/.github/workflows/nm-lm-eval.yml
@@ -107,11 +107,9 @@ jobs:
         uses: ./.github/actions/nm-install-whl/
         with:
             python: ${{ inputs.python }}
-            venv:
 
       - name: run lm-eval-accuracy
         uses: ./.github/actions/nm-lm-eval/
         with:
           python: ${{ inputs.python }}
-          venv:
           lm_eval_configuration: ${{ inputs.lm_eval_configuration }}

--- a/.github/workflows/nm-test.yml
+++ b/.github/workflows/nm-test.yml
@@ -122,8 +122,6 @@ jobs:
 
             - name: install whl
               uses: ./.github/actions/nm-install-whl/
-              with:
-                python: ${{ inputs.python }}
 
             - name: run buildkite script
               run: |

--- a/.github/workflows/nm-test.yml
+++ b/.github/workflows/nm-test.yml
@@ -124,7 +124,6 @@ jobs:
               uses: ./.github/actions/nm-install-whl/
               with:
                 python: ${{ inputs.python }}
-                venv:
 
             - name: run buildkite script
               run: |


### PR DESCRIPTION
the `venv` input assigned to some actions has not been set in a variety of workflows, in spite of it being required.  
In fact, the actions already have code to check the value and provide a reasonable substitute for it if it wasn't provided.
I've;
* modified the input declaration to indicate that it is optional, 
* with a default empty string value, and 
* removed the references to it from workflows that were passing in blank values.

I also updated the `nm-lm-eval` action to use the same pattern to test the value of the venv input, so that it is consistent with the other actions.

[This nm remote push run](https://github.com/neuralmagic/nm-vllm/actions/runs/9844629721) demonstrates that at least the `nm-test` workflow and called actions continues to work as expected.
