### PR TITLE
NM Profiler : Update visualize_trace.py

### DIFF
--- a/neuralmagic/tools/profiler/visualize_trace.py
+++ b/neuralmagic/tools/profiler/visualize_trace.py
@@ -397,7 +397,10 @@ if __name__ == "__main__":
                         help="Only graph the top `top_k` entries by time.")
     parser.add_argument("--fold-json-node",
                         nargs='+',
-                        default=['Sampler', 'LogitsProcessor'])
+                        default=['Sampler', 'LogitsProcessor'],
+                        help='Do not plot the children of these nodes. Let, \
+                              the node represent the aggregate of all its \
+                              children')
     parser.add_argument("--plot-metric", 
                         type=str,
                         default="cuda_time_ms",

--- a/neuralmagic/tools/profiler/visualize_trace.py
+++ b/neuralmagic/tools/profiler/visualize_trace.py
@@ -30,8 +30,8 @@ def get_entries_at_depth(depth: int,
 
     if curr_depth == 0 and largest_dist_from_leaf(node) <= (abs(depth) - 1):
         # The tree is not tall enough!
-        entries_and_traces.append((node["entry"] , trace))
-        return 
+        entries_and_traces.append((node["entry"], trace))
+        return
 
     if largest_dist_from_leaf(node) == (abs(depth) - 1):
         entries_and_traces.append((node["entry"], trace))
@@ -44,9 +44,10 @@ def get_entries_at_depth(depth: int,
                              curr_depth=curr_depth + 1,
                              trace=trace)
 
-def fold_nodes(root: dict, nodes_to_fold : List[str]):
 
-    stack : List[dict] = [root]
+def fold_nodes(root: dict, nodes_to_fold: List[str]):
+
+    stack: List[dict] = [root]
     while len(stack) != 0:
         node = stack.pop()
         if node['entry']['name'] in nodes_to_fold:
@@ -55,6 +56,7 @@ def fold_nodes(root: dict, nodes_to_fold : List[str]):
         for child in node["children"]:
             stack.append(child)
     return root
+
 
 ## Operation name cleanup utils ####
 
@@ -273,6 +275,7 @@ def plot_trace_df(traces_df: pd.DataFrame,
 
     plt.savefig(output, bbox_inches='tight')
     print("Created: ", output)
+
 
 def main(
         json_trace: Path,

--- a/neuralmagic/tools/profiler/visualize_trace.py
+++ b/neuralmagic/tools/profiler/visualize_trace.py
@@ -401,7 +401,8 @@ if __name__ == "__main__":
     parser.add_argument("--plot-metric", 
                         type=str,
                         default="cuda_time_ms",
-                        help='Metric to plot. some options are cuda_time_us, cuda_time_ms, pct_cuda_time')
+                        help='Metric to plot. some options are cuda_time_ms, \
+                                pct_cuda_time')
     parser.add_argument(
         "--step-plot-interval",
         type=int,

--- a/neuralmagic/tools/profiler/visualize_trace.py
+++ b/neuralmagic/tools/profiler/visualize_trace.py
@@ -268,7 +268,7 @@ def plot_trace_df(traces_df: pd.DataFrame,
 
     # Setup labels and title
     plt.setp(ax.get_xticklabels(), rotation=90)
-    ax.set_ylabel("time ms")
+    ax.set_ylabel(plot_metric)
     plt.suptitle(plot_title)
 
     plt.savefig(output, bbox_inches='tight')


### PR DESCRIPTION
Update visualize trace utility.
 - Add ability to plot decode steps 
 - Expose the metric to plot as a command line argument
 - Generate 2 plots - 1 for prefill and another for decode-steps and store them in the user given output directory
 - Remove the `ignore_sampler` arg, and instead add a `fold_json_node` arg - This argument collapses the specified JSON tree so the plot has less clutter.
 
Usage:
  - `python3 neuralmagic/tools/profiler/visualize_trace.py --json-trace profiler_fp8_trace.json --output-directory ./kernel  --level kernel`
      This command produce 2 output files : `kernel/prefill.png` and `kernel/decode_steps.png` which are stacked-bar graph plots. In these plots the operations are grouped together by high-level concepts such as `gemms`, `attention`, `rms-norm` etc.
![prefill](https://github.com/neuralmagic/nm-vllm/assets/3337719/9e135b6f-4e0f-4460-9d75-679114cc4ef4)  
![decode_steps](https://github.com/neuralmagic/nm-vllm/assets/3337719/2f1d0027-61d9-4b0e-a862-41e12b6ed6ae)

- `python3 neuralmagic/tools/profiler/visualize_trace.py --json-trace profiler_fp8_trace.json --output-directory ./module --level module   --plot-metric pct_cuda_time`
    This command also produces 2 output files : `module/prefill.png` and `module/decode_steps.png` which are stacked-bar graph plots. In these plots the bars sum up to a 100 as the requested plot metric is `pct_cuda_time`
![prefill](https://github.com/neuralmagic/nm-vllm/assets/3337719/b442810b-a1f0-42ad-9b1d-565d5d6d4881)
![decode_steps](https://github.com/neuralmagic/nm-vllm/assets/3337719/3650e7f1-8c78-4cab-a456-0715e0502a6c)
