### PR TITLE
Frontend mp flag

### DIFF
--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -1,4 +1,7 @@
-from typing import AsyncIterator, List, Mapping, Optional, Protocol
+from typing import (AsyncIterator, List, Mapping, Optional, Protocol,
+                    runtime_checkable)
+
+from transformers import PreTrainedTokenizer
 
 from vllm.config import DecodingConfig, ModelConfig
 from vllm.core.scheduler import SchedulerOutputs
@@ -10,22 +13,22 @@ from vllm.prompt_adapter.request import PromptAdapterRequest
 from vllm.sampling_params import SamplingParams
 from vllm.sequence import SamplerOutput
 
-from transformers import PreTrainedTokenizer
 
+@runtime_checkable
 class VLLMBackend(Protocol):
     """Protocol class for asynchronous vllm backends"""
 
     @property
     def is_running(self) -> bool:
-        pass
+        ...
 
     @property
     def is_stopped(self) -> bool:
-        pass
+        ...
 
     @property
     def errored(self) -> bool:
-        pass
+        ...
 
     async def generate(
         self,
@@ -76,4 +79,3 @@ class VLLMBackend(Protocol):
         model_output: Optional[List[SamplerOutput]] = None,
     ) -> None:
         pass
-    

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -131,9 +131,14 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
     parser.add_argument(
         "--return-tokens-as-token-ids",
         action="store_true",
-        help="When --max-logprobs is specified, represents single tokens as"
-        "strings of the form 'token_id:{token_id}' so that tokens that"
+        help="When --max-logprobs is specified, represents single tokens as "
+        "strings of the form 'token_id:{token_id}' so that tokens that "
         "are not JSON-encodable can be identified.")
+    parser.add_argument(
+        "--disable-frontend-multiprocessing",
+        action="store_true",
+        help="If specified, will run the OpenAI frontend server in the same "
+        "proecss as the model servinge engine.")
 
     parser = AsyncEngineArgs.add_cli_args(parser)
 

--- a/vllm/entrypoints/openai/rpc/__init__.py
+++ b/vllm/entrypoints/openai/rpc/__init__.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from typing import Optional, Mapping
 from enum import Enum
+from typing import Mapping, Optional
 
 from vllm.inputs import PromptInputs
 from vllm.lora.request import LoRARequest

--- a/vllm/entrypoints/openai/rpc/client.py
+++ b/vllm/entrypoints/openai/rpc/client.py
@@ -1,19 +1,19 @@
-from typing import AsyncIterator, Optional, Mapping
+import pickle
+from typing import AsyncIterator, Mapping, Optional
 
-from vllm.config import ModelConfig, DecodingConfig
+import zmq
+import zmq.asyncio
+
+from vllm.config import DecodingConfig, ModelConfig
+from vllm.entrypoints.openai.rpc import (VLLM_GENERATE_RPC_PATH,
+                                         VLLM_GET_DATA_RPC_PATH,
+                                         VLLM_IS_READY_RPC_PATH,
+                                         GenerateRequest, GetDataRequest)
 from vllm.inputs import PromptInputs
 from vllm.lora.request import LoRARequest
 from vllm.outputs import RequestOutput
 from vllm.prompt_adapter.request import PromptAdapterRequest
 from vllm.sampling_params import SamplingParams
-from vllm.entrypoints.openai.rpc import (VLLM_GENERATE_RPC_PATH,
-                                         VLLM_GET_DATA_RPC_PATH,
-                                         VLLM_IS_READY_RPC_PATH,
-                                         GenerateRequest, GetDataRequest)
-
-import zmq
-import zmq.asyncio
-import pickle
 
 
 class RPCClient:

--- a/vllm/entrypoints/openai/rpc/server.py
+++ b/vllm/entrypoints/openai/rpc/server.py
@@ -1,16 +1,17 @@
 import asyncio
 import pickle
-import zmq
-import zmq.asyncio
 import signal
 
+import zmq
+import zmq.asyncio
+
 from vllm import AsyncLLMEngine
-from vllm.usage.usage_lib import UsageContext
 from vllm.entrypoints.openai.rpc import (VLLM_GENERATE_RPC_PATH,
                                          VLLM_GET_DATA_RPC_PATH,
                                          VLLM_IS_READY_RPC_PATH,
                                          GetDataRequest)
 from vllm.logger import init_logger
+from vllm.usage.usage_lib import UsageContext
 
 logger = init_logger('vllm.entrypoints.openai.rpc.server')
 


### PR DESCRIPTION
@robertgshaw2-neuralmagic 

This adds the `--disable-frontend-multiprocessing` flag and should also correctly pick up embeddings models to disable the multiprocessing here. (Also some unrelated formatting changes)

The backend stuff is wrapped up in a context manager that handles the process startup and shutdown at exit as well, so that we don't have to muck around much in the existing server lifecycle code