### PR TITLE
Add health probe

### DIFF
--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -79,3 +79,6 @@ class VLLMBackend(Protocol):
         model_output: Optional[List[SamplerOutput]] = None,
     ) -> None:
         pass
+
+    async def check_health(self) -> None:
+        """Raise if unhealthy"""

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -18,11 +18,11 @@ from prometheus_client import make_asgi_app
 from starlette.routing import Mount
 from transformers import AutoTokenizer
 
-from vllm.config import ModelConfig
 import vllm.envs as envs
+from vllm.config import ModelConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
-from vllm.engine.protocol import VLLMBackend
 from vllm.engine.async_llm_engine import AsyncLLMEngine
+from vllm.engine.protocol import VLLMBackend
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.cli_args import make_arg_parser
 # yapf conflicts with isort for this block

--- a/vllm/entrypoints/openai/rpc/__init__.py
+++ b/vllm/entrypoints/openai/rpc/__init__.py
@@ -10,6 +10,7 @@ from vllm.sampling_params import SamplingParams
 VLLM_GENERATE_RPC_PATH = "tcp://localhost:5570"
 VLLM_GET_DATA_RPC_PATH = "tcp://localhost:5571"
 VLLM_IS_READY_RPC_PATH = "tcp://localhost:5572"
+VLLM_HEALTH_CHECK_PATH = "tcp://localhost:5584"
 
 
 @dataclass

--- a/vllm/entrypoints/openai/rpc/__init__.py
+++ b/vllm/entrypoints/openai/rpc/__init__.py
@@ -10,7 +10,7 @@ from vllm.sampling_params import SamplingParams
 VLLM_GENERATE_RPC_PATH = "tcp://localhost:5570"
 VLLM_GET_DATA_RPC_PATH = "tcp://localhost:5571"
 VLLM_IS_READY_RPC_PATH = "tcp://localhost:5572"
-VLLM_HEALTH_CHECK_PATH = "tcp://localhost:5584"
+VLLM_HEALTH_CHECK_PATH = "tcp://localhost:5573"
 
 
 @dataclass


### PR DESCRIPTION
So the server won't delete itself 😉 

Will ensure shutdown when the backend terminates, if /health probes are used to manage container lifecycle. We could consider internal heartbeats for this as well, but that's probably out of scope for initial work here.