### PR TITLE
Group Index Conditioning

### DIFF
--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -161,3 +161,17 @@ def test_compressed_tensors_kv_cache(vllm_runner):
     with vllm_runner(model_path, kv_cache_dtype="fp8") as llm:
         output = llm.generate_greedy("Hello world!", max_tokens=20)
         assert output
+
+
+def test_compressed_tensors_actorder_weight(vllm_runner):
+    model_path = "kylesayrs/TinyLlama/TinyLlama-1.1B-Chat-v1.0-actorder-weight-e2e
+    with vllm_runner(model_path) as llm:
+        output = llm.generate_greedy("Hello world!", max_tokens=20)
+        assert output
+
+
+def test_compressed_tensors_actorder_group(vllm_runner):
+    model_path = "kylesayrs/TinyLlama/TinyLlama-1.1B-Chat-v1.0-actorder-group-e2e"
+    with vllm_runner(model_path) as llm:
+        output = llm.generate_greedy("Hello world!", max_tokens=20)
+        assert output

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -164,14 +164,16 @@ def test_compressed_tensors_kv_cache(vllm_runner):
 
 
 def test_compressed_tensors_actorder_weight(vllm_runner):
-    model_path = "kylesayrs/TinyLlama/TinyLlama-1.1B-Chat-v1.0-actorder-weight-e2e
+    model_path = (
+        "kylesayrs/TinyLlama/TinyLlama-1.1B-Chat-v1.0-actorder-weight-e2e")
     with vllm_runner(model_path) as llm:
         output = llm.generate_greedy("Hello world!", max_tokens=20)
         assert output
 
 
 def test_compressed_tensors_actorder_group(vllm_runner):
-    model_path = "kylesayrs/TinyLlama/TinyLlama-1.1B-Chat-v1.0-actorder-group-e2e"
+    model_path = (
+        "kylesayrs/TinyLlama/TinyLlama-1.1B-Chat-v1.0-actorder-group-e2e")
     with vllm_runner(model_path) as llm:
         output = llm.generate_greedy("Hello world!", max_tokens=20)
         assert output

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -164,16 +164,14 @@ def test_compressed_tensors_kv_cache(vllm_runner):
 
 
 def test_compressed_tensors_actorder_weight(vllm_runner):
-    model_path = (
-        "kylesayrs/TinyLlama/TinyLlama-1.1B-Chat-v1.0-actorder-weight-e2e")
+    model_path = "kylesayrs/TinyLlama-1.1B-Chat-v1.0-actorder-weight-e2e"
     with vllm_runner(model_path) as llm:
         output = llm.generate_greedy("Hello world!", max_tokens=20)
         assert output
 
 
 def test_compressed_tensors_actorder_group(vllm_runner):
-    model_path = (
-        "kylesayrs/TinyLlama/TinyLlama-1.1B-Chat-v1.0-actorder-group-e2e")
+    model_path = "kylesayrs/TinyLlama-1.1B-Chat-v1.0-actorder-group-e2e"
     with vllm_runner(model_path) as llm:
         output = llm.generate_greedy("Hello world!", max_tokens=20)
         assert output

--- a/tests/weight_loading/models.txt
+++ b/tests/weight_loading/models.txt
@@ -15,8 +15,8 @@ compressed-tensors, nm-testing/Phi-3-mini-128k-instruct-FP8, main
 compressed-tensors, neuralmagic/Phi-3-medium-128k-instruct-quantized.w4a16, main
 compressed-tensors, nm-testing/Mixtral-8x7B-Instruct-v0.1-W4A16-quantized, main
 compressed-tensors, nm-testing/Mixtral-8x7B-Instruct-v0.1-W4A16-channel-quantized, main
-compressed-tensors, kylesayrs/TinyLlama/TinyLlama-1.1B-Chat-v1.0-actorder-weight-e2e, main
-compressed-tensors, kylesayrs/TinyLlama/TinyLlama-1.1B-Chat-v1.0-actorder-group-e2e, main
+compressed-tensors, kylesayrs/TinyLlama-1.1B-Chat-v1.0-actorder-weight-e2e, main
+compressed-tensors, kylesayrs/TinyLlama-1.1B-Chat-v1.0-actorder-group-e2e, main
 awq, casperhansen/mixtral-instruct-awq, main
 awq_marlin, casperhansen/mixtral-instruct-awq, main
 fp8, neuralmagic/Meta-Llama-3-8B-Instruct-FP8-KV, main

--- a/tests/weight_loading/models.txt
+++ b/tests/weight_loading/models.txt
@@ -15,6 +15,8 @@ compressed-tensors, nm-testing/Phi-3-mini-128k-instruct-FP8, main
 compressed-tensors, neuralmagic/Phi-3-medium-128k-instruct-quantized.w4a16, main
 compressed-tensors, nm-testing/Mixtral-8x7B-Instruct-v0.1-W4A16-quantized, main
 compressed-tensors, nm-testing/Mixtral-8x7B-Instruct-v0.1-W4A16-channel-quantized, main
+compressed-tensors, kylesayrs/TinyLlama/TinyLlama-1.1B-Chat-v1.0-actorder-weight-e2e, main
+compressed-tensors, kylesayrs/TinyLlama/TinyLlama-1.1B-Chat-v1.0-actorder-group-e2e, main
 awq, casperhansen/mixtral-instruct-awq, main
 awq_marlin, casperhansen/mixtral-instruct-awq, main
 fp8, neuralmagic/Meta-Llama-3-8B-Instruct-FP8-KV, main

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -232,8 +232,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                 return CompressedTensorsWNA16(
                     num_bits=weight_quant.num_bits,
                     strategy=weight_quant.strategy,
-                    group_size=weight_quant.group_size,
-                    actorder=weight_quant.actorder)
+                    group_size=weight_quant.group_size)
 
         # Detect If Activation Quantization.
         # TODO @dsikka: clean-up conditions

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -123,10 +123,9 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
                                          weight_loader=weight_loader)
 
         # group index (for activation reordering)
-        weight_g_idx = BasevLLMParameter(data=torch.full((input_size_per_partition, ),
-                                                  -1,
-                                                  dtype=torch.int32),
-                                  weight_loader=weight_loader)
+        weight_g_idx = BasevLLMParameter(data=torch.full(
+            (input_size_per_partition, ), -1, dtype=torch.int32),
+                                         weight_loader=weight_loader)
 
         layer.register_parameter("weight_packed", weight)
         layer.register_parameter("weight_scale", weight_scale)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -7,9 +7,9 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsScheme)
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
-    apply_gptq_marlin_linear, marlin_is_k_full, marlin_make_empty_g_idx,
-    marlin_make_workspace, marlin_permute_scales, marlin_sort_g_idx,
-    replace_tensor, verify_marlin_supported, verify_marlin_supports_shape)
+    apply_gptq_marlin_linear, marlin_make_empty_g_idx, marlin_make_workspace,
+    marlin_permute_scales, marlin_sort_g_idx, replace_tensor,
+    verify_marlin_supported, verify_marlin_supports_shape)
 from vllm.model_executor.parameter import (BasevLLMParameter,
                                            ChannelQuantScaleParameter,
                                            GroupQuantScaleParameter,
@@ -31,8 +31,7 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
     def __init__(self,
                  strategy: str,
                  num_bits: int,
-                 group_size: Optional[int] = None,
-                 actorder: bool = False):
+                 group_size: Optional[int] = None):
 
         self.pack_factor = 32 // num_bits
         self.strategy = strategy
@@ -50,15 +49,6 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
 
         self.quant_type = WNA16_SUPPORTED_TYPES_MAP[num_bits]
 
-        if actorder and self.group_size == -1:
-            # In this case, actorder == True is the same as actorder == False
-            # (since we have only one group per output channel)
-            logger.warning(
-                "Model must be quantized with group_size > 0 in order to use "
-                "activation ordering")
-            actorder = False
-        self.actorder = actorder
-
         # Verify supported on platform.
         verify_marlin_supported(quant_type=self.quant_type,
                                 group_size=self.group_size)
@@ -75,7 +65,6 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
                        **kwargs):
 
         output_size_per_partition = sum(output_partition_sizes)
-        is_row_parallel = input_size != input_size_per_partition
 
         # If group_size is -1, we are in channelwise case.
         channelwise = (self.group_size == -1)
@@ -133,21 +122,21 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
                                                           dtype=torch.int64),
                                          weight_loader=weight_loader)
 
-        # G_IDX (for activation reordering)
-        g_idx = BasevLLMParameter(data=torch.empty(input_size_per_partition,
-                                                   dtype=torch.int32),
+        # group index (for activation reordering)
+        weight_g_idx = BasevLLMParameter(data=torch.full((input_size_per_partition, ),
+                                                  -1,
+                                                  dtype=torch.int32),
                                   weight_loader=weight_loader)
 
         layer.register_parameter("weight_packed", weight)
         layer.register_parameter("weight_scale", weight_scale)
         layer.register_parameter("weight_shape", weight_shape)
-        layer.register_parameter("weight_g_idx", g_idx)
+        layer.register_parameter("weight_g_idx", weight_g_idx)
 
         layer.input_size_per_partition = input_size_per_partition
         layer.output_size_per_partition = output_size_per_partition
         layer.input_size = input_size
         layer.group_size = group_size
-        layer.is_k_full = marlin_is_k_full(self.actorder, is_row_parallel)
 
     # Checkpoints are serialized in compressed-tensors format, which is
     # different from marlin format. Handle repacking here.
@@ -159,7 +148,8 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
             layer.output_size_per_partition, device)
 
         # Handle sorting for activation reordering if needed.
-        if self.actorder:
+        has_g_idx = -1 not in layer.weight_g_idx
+        if has_g_idx:
             g_idx, g_idx_sort_indices = marlin_sort_g_idx(layer.weight_g_idx)
             layer.g_idx_sort_indices = g_idx_sort_indices
             replace_tensor(layer, "weight_g_idx", g_idx)
@@ -188,7 +178,7 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
         marlin_scales = marlin_permute_scales(
             layer.weight_scale,
             size_k=(layer.input_size
-                    if self.actorder else layer.input_size_per_partition),
+                    if has_g_idx else layer.input_size_per_partition),
             size_n=layer.output_size_per_partition,
             group_size=layer.group_size)
         replace_tensor(layer, "weight_scale", marlin_scales)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -1,6 +1,6 @@
 import re
 from enum import Enum
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional, Union
 
 from pydantic import BaseModel, Field
 from torch.nn import Module
@@ -40,6 +40,20 @@ class QuantizationStrategy(str, Enum):
     TOKEN = "token"
 
 
+class ActivationOrderingStrategy(str, Enum):
+    """
+    Enum storing strategies for activation ordering
+
+    Weight := only reorder weight, not groups (default)
+    Grouped := reorder groups and weight
+    Off := do not reorder by activations
+    """
+
+    WEIGHT = "weight"
+    GROUP = "group"
+    OFF = "off"
+
+
 class QuantizationArgs(BaseModel):
     """
     User facing arguments used to define a quantization config 
@@ -69,7 +83,8 @@ class QuantizationArgs(BaseModel):
     strategy: Optional[QuantizationStrategy] = None
     block_structure: Optional[str] = None
     dynamic: bool = False
-    actorder: bool = False
+    actorder: Union[ActivationOrderingStrategy,
+                    bool] = ActivationOrderingStrategy.OFF
     observer: str = Field(
         default="minmax",
         description=("The class to use to compute the quantization param - "

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -129,16 +129,16 @@ def marlin_make_workspace(output_size_per_partition: int,
                        requires_grad=False)
 
 
-def marlin_is_k_full(actorder: bool, is_row_parallel: bool) -> bool:
-    return (not actorder) or (actorder and not is_row_parallel)
+def marlin_is_k_full(has_g_idx: bool, is_row_parallel: bool) -> bool:
+    return (not has_g_idx) or (not is_row_parallel)
 
 
-def marlin_repeat_scales_on_all_ranks(actorder: bool, group_size: int,
+def marlin_repeat_scales_on_all_ranks(has_g_idx: bool, group_size: int,
                                       is_row_parallel: bool) -> bool:
     # Need to repeat scales on every rank if actorder or
     # channelwise and RowParallelLinear
     is_channelwise = group_size == -1
-    return actorder or (is_channelwise and is_row_parallel)
+    return has_g_idx or (is_channelwise and is_row_parallel)
 
 
 def marlin_make_empty_g_idx(device: torch.device) -> torch.Tensor:


### PR DESCRIPTION
## Purpose ##
* Support models quantized with actorder="weight", which is a special kind of activation ordering which orders the weight but not the group, therefore not requiring g_idx

## Changes ##
* Update activation-ordering config model to support new config options, while still being backwards compatible with actorder=True/False
* Replace logic for `actorder==True` with `has_g_idx==True`
  * This handles the actorder=weight case, since that case does not load g_idx tensors
* Add e2e tests of activation ordering models

## Testing ##
### Accuracy
Full Precision
```
vllm (pretrained=Qwen/Qwen2-0.5B-Instruct,add_bos_token=True), gen_kwargs: (None), limit: 1000.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|?  |0.394|?  |0.0155|
|     |       |strict-match    |     5|exact_match|?  |0.393|?  |0.0155|
```

No Activation Ordering
```
vllm (pretrained=/home/ksayers/llm-compressor/qwen_group_only,add_bos_token=True), gen_kwargs: (None), limit: 1000.0, num_fewshot: 5, batch_size: auto                               
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|                                                                                                             
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|                                                                                                             
|gsm8k|      3|flexible-extract|     5|exact_match|?  |0.228|?  |0.0133|                                                                                                             
|     |       |strict-match    |     5|exact_match|?  |0.217|?  |0.0130| 
```

Group Activation Ordering
```
vllm (pretrained=/home/ksayers/llm-compressor/qwen_actorder_group,add_bos_token=True), gen_kwargs: (None), limit: 1000.0, num_fewshot: 5, batch_size: auto                           
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|                                                                                                             
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|                                                                                                             
|gsm8k|      3|flexible-extract|     5|exact_match|?  |0.241|?  |0.0135|                                                                                                             
|     |       |strict-match    |     5|exact_match|?  |0.236|?  |0.0134|
```

Weight-only Activation Ordering
```
vllm (pretrained=/home/ksayers/llm-compressor/qwen_actorder_weight,add_bos_token=True), gen_kwargs: (None), limit: 1000.0, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|?  |0.254|?  |0.0138|
|     |       |strict-match    |     5|exact_match|?  |0.213|?  |0.0130|
```

### Latency ###
Full Precision
```
Avg latency: 0.612304248350362 seconds
10% percentile latency: 0.6050410680472851 seconds
25% percentile latency: 0.6059907954186201 seconds
50% percentile latency: 0.6098776273429394 seconds
75% percentile latency: 0.6107742763124406 seconds
90% percentile latency: 0.6114723403006792 seconds
99% percentile latency: 0.6905647566355766 seconds
```

No Activation Ordering
```
Avg latency: 0.451185735501349 seconds
10% percentile latency: 0.4459945809096098 seconds
25% percentile latency: 0.44648625515401363 seconds
50% percentile latency: 0.4473606375977397 seconds
75% percentile latency: 0.4487249795347452 seconds
90% percentile latency: 0.45016821939498186 seconds
99% percentile latency: 0.5247877304255963 seconds
```

Group Activation Ordering
```
Avg latency: 0.47711189221590755 seconds
10% percentile latency: 0.47196690943092107 seconds
25% percentile latency: 0.4725433448329568 seconds
50% percentile latency: 0.47307876218110323 seconds
75% percentile latency: 0.4750088737346232 seconds
90% percentile latency: 0.4756721451878548 seconds
99% percentile latency: 0.5509468417987229 seconds
```

Weight Activation Ordering
```
Avg latency: 0.4507347485671441 seconds
10% percentile latency: 0.4456333613023162 seconds
25% percentile latency: 0.446005588863045 seconds
50% percentile latency: 0.44688841979950666 seconds
75% percentile latency: 0.44848238583654165 seconds
90% percentile latency: 0.4493972914293408 seconds
99% percentile latency: 0.5238330581225455 seconds
```